### PR TITLE
adding grid-based movement to frontend

### DIFF
--- a/Gloomhaven/pyxel_ui/pyxel_main.py
+++ b/Gloomhaven/pyxel_ui/pyxel_main.py
@@ -328,7 +328,7 @@ class PyxelView:
             - self.canvas.tile_width_px
         )
         self.direction = 1
-        test_duration = 300
+        test_duration = 700
         test_action = Action(
             character="knight",
             animation_type="walk",
@@ -353,9 +353,18 @@ class PyxelView:
             to_grid_pos=(1, 2),
             duration_ms=test_duration,
         )
+        test_action4 = Action(
+            character="knight",
+            animation_type="walk",
+            direction="east",
+            from_grid_pos=(1, 2),
+            to_grid_pos=(2, 2),
+            duration_ms=test_duration,
+        )
         self.action_queue.enqueue(test_action)
         self.action_queue.enqueue(test_action2)
         self.action_queue.enqueue(test_action3)
+        self.action_queue.enqueue(test_action4)
         # end temp values
 
         pyxel.load("../my_resource.pyxres")
@@ -376,6 +385,8 @@ class PyxelView:
         end_tile_pos: tuple[int, int],
         tween_time: int,
     ) -> deque[tuple[int, int]]:
+        assert tween_time > FRAME_DURATION_MS, "action smaller than frame rate"
+
         start_px_x, start_px_y = self.convert_grid_to_pixel_pos(
             start_tile_pos[0], start_tile_pos[1]
         )
@@ -383,21 +394,21 @@ class PyxelView:
             end_tile_pos[0], end_tile_pos[1]
         )
 
-        assert tween_time > FRAME_DURATION_MS, "action smaller than frame rate"
         step_count = tween_time // FRAME_DURATION_MS
         diff_px_x = end_px_x - start_px_x
         step_px_x = diff_px_x // step_count
         diff_px_y = end_px_y - start_px_y
         step_px_y = diff_px_y // step_count
-        steps: deque = deque([])
 
+        steps: deque = deque([])
         for step in range(step_count + 1):
             steps.append(
                 (start_px_x + (step * step_px_x), start_px_y + (step * step_px_y))
             )
 
-        # This guarantees that the sprite will end up on correct position
+        # This guarantees that the sprite will end up at the correct position
         steps.append((end_px_x, end_px_y))
+
         return steps
 
     def convert_and_append_move_steps_to_action(self, action: Action) -> Action:

--- a/Gloomhaven/pyxel_ui/tests/test_pyxel.py
+++ b/Gloomhaven/pyxel_ui/tests/test_pyxel.py
@@ -5,6 +5,8 @@ from pyxel_main import (
     PyxelActionQueue,
 )
 
+# python3 -m unittest discover -s tests
+
 
 class TestPyxelActionQueue(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
the knight can now be moved from one tile to another. this is done by adding actions to the `PyxelView.action_queue` and pyxel's update loop will process them one at a time. 

Actions have the following structure
```python
@dataclass
class Action:
    character: str
    animation_type: str
    direction: Direction
    from_grid_pos: tuple
    to_grid_pos: tuple
    duration_ms: int = 1000
    action_steps: Optional[deque[tuple[int, int]]] = None
```

Here's an overview of how sprite movement and the coming animation process work:
We clear and redraw the entire board on every update loop. It would probably be better to optimize this later since most of the board will remain static. The draw loop displays walls > floors > characters > grid. When drawing the characters, we iterate over `PyxelView.characters`, a dict which holds each character's current position on the board, the sprite type, and animation frame.
All movement and animation works by updating values in this dict and having the change reflected in the next draw cycle.
Movements are converted from grid coordinates to pixel values and are broken into discrete steps that are stored in the action's `action_steps`, a list of tuples. The number of steps controls the speed of the movement/animation is determined by $\frac{\text{duration (ms)}}{\text{frame duration (ms)}}$.

I'll work on refactoring what I have before merging.

This the movements should be limited to adjacent tiles, though this check should probably be handled by the game logic.