### PR TITLE
fast text refresh for log and cards

### DIFF
--- a/Gloomhaven/backend/models/pyxel_backend.py
+++ b/Gloomhaven/backend/models/pyxel_backend.py
@@ -13,8 +13,8 @@ class PyxelManager:
         self.shared_action_queue = shared_action_queue
         self.move_duration = 700
         self.log = ListWithUpdate([], self.load_log)
-        self.floor_color_map=[]
-        self.wall_color_map=[]
+        self.floor_color_map = []
+        self.wall_color_map = []
 
     def load_board(self, locations, terrain):
         entities = []
@@ -65,7 +65,7 @@ class PyxelManager:
             map_width=self.board_width,
             valid_map_coordinates=valid_map_coordinates,
             floor_color_map=self.floor_color_map,
-            wall_color_map=self.wall_color_map
+            wall_color_map=self.wall_color_map,
         )
         self.shared_action_queue.enqueue(task)
         self.shared_action_queue.enqueue(tasks.AddEntitiesTask(entities=entities))
@@ -73,7 +73,7 @@ class PyxelManager:
     def clear_log(self):
         self.log = ListWithUpdate([], self.load_log)
         self.load_log(self.log)
-        
+
     def move_character(self, char, old_location, new_location):
         task = tasks.ActionTask(
             char.id,
@@ -154,6 +154,10 @@ class PyxelManager:
         )
         self.shared_action_queue.enqueue(task)
 
-    def set_level_map_colors(self, floor_color_map: list[tuple[int,int]], wall_color_map: list[tuple[int,int]]):
-        self.floor_color_map=floor_color_map
-        self.wall_color_map=wall_color_map
+    def set_level_map_colors(
+        self,
+        floor_color_map: list[tuple[int, int]],
+        wall_color_map: list[tuple[int, int]],
+    ):
+        self.floor_color_map = floor_color_map
+        self.wall_color_map = wall_color_map

--- a/Gloomhaven/pyxel_ui/controllers/view_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/view_manager.py
@@ -88,11 +88,11 @@ class ViewManager:
         self.action_card_view.draw()
 
     def update_map(
-            self, 
-            valid_floor_coordinates: list[tuple[int, int]], 
-            floor_color_map=[],
-            wall_color_map=[]
-            ) -> None:
+        self,
+        valid_floor_coordinates: list[tuple[int, int]],
+        floor_color_map=[],
+        wall_color_map=[],
+    ) -> None:
         if floor_color_map:
             self.map_view.floor_color_map = floor_color_map
         if wall_color_map:

--- a/Gloomhaven/pyxel_ui/engine.py
+++ b/Gloomhaven/pyxel_ui/engine.py
@@ -10,10 +10,10 @@ from pyxel_ui.constants import (
     MAP_TILE_HEIGHT_PX,
     MAP_TILE_WIDTH_PX,
 )
-from .models.tasks import BoardInitTask, ActionTask
+from .models.tasks import ActionTask
 from pyxel_ui.models.pyxel_task_queue import PyxelTaskQueue
 from pyxel_ui.controllers.view_manager import ViewManager
-from .utils import round_to_multiple
+from .utils import round_down_to_nearest_multiple
 
 # TODO(john): enable mouse control
 # TODO(john): create highlighting class and methods.
@@ -85,26 +85,27 @@ class PyxelEngine:
                 self.view_manager.action_card_view.current_card_page -= 1
                 self.view_manager.action_card_view.draw()
 
-        # Handle cursor redraws
+        # Handle cursor redraws and grid
         curr_mouse_x, curr_mouse_y = pyxel.mouse_x, pyxel.mouse_y
         if self.last_mouse_pos != (curr_mouse_x, curr_mouse_y):
             last_mouse_x, last_mouse_y = self.last_mouse_pos
             if view := self.view_manager.get_view_for_coordinate_px(
                 last_mouse_x, last_mouse_y
             ):
-                view.draw()
+                view.redraw()
 
-            grid_left_px = round_to_multiple(curr_mouse_x, MAP_TILE_WIDTH_PX)
-            grid_top_px = round_to_multiple(curr_mouse_y, MAP_TILE_HEIGHT_PX)
-            print(f"{grid_left_px=} - {grid_top_px=}")
+            # Grid concerns
+            grid_left_px = round_down_to_nearest_multiple(
+                curr_mouse_x, MAP_TILE_WIDTH_PX
+            )
+            grid_top_px = round_down_to_nearest_multiple(
+                curr_mouse_y, MAP_TILE_HEIGHT_PX
+            )
             self.view_manager.draw_grid(
                 grid_left_px, grid_top_px, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX
             )
 
             self.last_mouse_pos = (curr_mouse_x, curr_mouse_y)
-
-        # Handle grid draw
-        # if self.last_mouse_pos != (curr_mouse_x, curr_mouse_y):
 
     def draw(self):
         """everything in the task queue draws itself,
@@ -112,8 +113,6 @@ class PyxelEngine:
         we're not redrawing the canvas unless there's something
         new to draw!
         """
-        # this is also very slow with the new font implementation
-        # self.view_manager.draw_whole_game()
         # Calculate duration and framerate
         # loop_duration = time.time() - self.start_time
         # self.loop_durations.append(loop_duration)

--- a/Gloomhaven/pyxel_ui/models/font.py
+++ b/Gloomhaven/pyxel_ui/models/font.py
@@ -9,7 +9,6 @@ class PixelFont:
         self.medium_font = ImageFont.truetype(font_path, 8)
         self.large_font = ImageFont.truetype(font_path, 12)
         self.pyxel = pyxel
-        self.text_pixels: dict[tuple[int, int], tuple[int, int, int]] = {}
 
     def get_line_height(self, size="medium"):
         """Get the line height for a given font size"""
@@ -57,7 +56,7 @@ class PixelFont:
         lines = []
         for paragraph in text.split("\n"):
             # Split on space but keep empty strings to preserve spacing
-            words = paragraph.split(' ')
+            words = paragraph.split(" ")
             if not words:
                 lines.append("")
                 continue
@@ -67,7 +66,7 @@ class PixelFont:
 
             for word in words[1:]:
                 # Add the space and word even if word is empty (was a space in original)
-                next_piece = ' ' + word
+                next_piece = " " + word
                 word_width = self.get_text_width(next_piece, size)
 
                 if current_width + word_width <= max_width:
@@ -81,6 +80,10 @@ class PixelFont:
             lines.append(current_line)
 
         return lines
+
+    def redraw_text(self, col, text_pixels) -> None:
+        for px_x, px_y in text_pixels:
+            self.pyxel.pset(px_x, px_y, col)
 
     def draw_text(self, x, y, text, col, size="medium", max_width=None):
         """
@@ -97,6 +100,8 @@ class PixelFont:
             max_width: Optional maximum width in pixels. Text will wrap if it exceeds this width.
         """
         pyxel = self.pyxel
+
+        text_pixels = []
 
         # Split and wrap text into lines
         lines = self.wrap_text(str(text), max_width, size)
@@ -134,9 +139,12 @@ class PixelFont:
             for py in range(h):
                 for px in range(w):
                     if pixels[px, py]:
+                        text_pixels.append((x + px - padding, current_y + py - padding))
                         pyxel.pset(x + px - padding, current_y + py - padding, col)
 
             current_y += line_height
+
+        return text_pixels
 
     def get_text_height(self, text, size="medium", max_width=None):
         """

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -131,12 +131,11 @@ class BoardInitTask:
     floor_color_map: Optional[list[tuple[int, int]]] = None
     wall_color_map: Optional[list[tuple[int, int]]] = None
 
-
     def perform(self, view_manager):
         view_manager.update_map(
-            self.valid_map_coordinates,
-            self.floor_color_map,
-            self.wall_color_map)
+            self.valid_map_coordinates, self.floor_color_map, self.wall_color_map
+        )
+
 
 @dataclass
 class ActionTask(Task):

--- a/Gloomhaven/pyxel_ui/models/view_section.py
+++ b/Gloomhaven/pyxel_ui/models/view_section.py
@@ -29,7 +29,7 @@ class ViewSection(abc.ABC):
         self.bounding_coordinate = bounding_coordinate
         self.end_pos = self.bounding_coordinate
 
-    def clear_bounds(self):
+    def clear_bounds(self) -> None:
         """a function to clear the view's area before redrawing itself"""
         pyxel.rect(
             self.start_pos[0],
@@ -38,6 +38,9 @@ class ViewSection(abc.ABC):
             self.end_pos[1] - self.start_pos[1],
             0,
         )
+
+    def redraw(self) -> None:
+        self.draw()
 
     @abc.abstractmethod
     def draw(self):
@@ -48,13 +51,36 @@ class LogView(ViewSection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.log: list[str] = []
+        self._log: list[str] = []
+        self.is_log_changed = False
         self.round_number: int = 0
         self.acting_character_name: str = ""
         # !!! I want to set this dynamically based on the amount of space we have
         self.max_log_lines: int = MAX_LOG_LINES
+        self.text_pixels: list[tuple[int, int]] = None
+
+    @property
+    def log(self):
+        return self._log
+
+    @log.setter
+    def log(self, new_log: list[str]):
+        """Prevents unnecessary redraws by rejecting log updates when content has not changed"""
+        if new_log != self._log:
+            self._log = new_log
+            self.is_log_changed = True
+
+    def redraw(self) -> None:
+        self.clear_bounds()
+        if not self.log and self.round_number <= 0:
+            return
+        self.font.redraw_text(7, self.text_pixels)
 
     def draw(self) -> None:
+        if not self.is_log_changed:
+            return
+
+        self.text_pixels = []
         self.clear_bounds()
         if not self.log and self.round_number <= 0:
             return
@@ -70,13 +96,15 @@ class LogView(ViewSection):
             )
 
         def draw_line(text: str, y_pos: int, size: str = "medium") -> int:
-            self.font.draw_text(
-                self.start_pos[0],
-                y_pos,
-                text,
-                col=7,
-                size=size,
-                max_width=self.bounding_coordinate[0] - self.start_pos[0],
+            self.text_pixels.extend(
+                self.font.draw_text(
+                    self.start_pos[0],
+                    y_pos,
+                    text,
+                    col=7,
+                    size=size,
+                    max_width=self.bounding_coordinate[0] - self.start_pos[0],
+                )
             )
             return y_pos + get_line_height(text)
 
@@ -105,8 +133,7 @@ class LogView(ViewSection):
         for line in lines:
             current_y = draw_line(line, current_y)
 
-        # Why are we re-sizing the log view port?
-        # self.end_pos = (self.bounding_coordinate[0], current_y)
+        self.is_log_changed = False
 
 
 class MapView(ViewSection):
@@ -235,8 +262,17 @@ class ActionCardView(ViewSection):
         self.action_card_log: list[str] = []
         self.current_card_page = 0
         self.cards_per_page = 3
+        self.text_pixels: list[tuple[int, int]] = None
+
+    def redraw(self) -> None:
+        self.clear_bounds()
+        if not self.action_card_log:
+            return
+        self.font.redraw_text(7, self.text_pixels)
 
     def draw(self) -> None:
+        print("action card draw")
+        self.text_pixels = []
         self.clear_bounds()
         if not self.action_card_log:
             return
@@ -258,7 +294,11 @@ class ActionCardView(ViewSection):
         ) // self.cards_per_page
         # Draw only the current page of cards
         for card in self.action_card_log[start_idx:end_idx]:
-            self.font.draw_text(x, y, card, col=7, size="medium", max_width=card_width)
+            self.text_pixels.extend(
+                self.font.draw_text(
+                    x, y, card, col=7, size="medium", max_width=card_width
+                )
+            )
             x += card_width + card_border
 
         # !!! should change this to measure the height of the cards and page indicator
@@ -390,5 +430,8 @@ def draw_grid(
     px_width: int,
     px_height: int,
     color: int = 3,
+    dither: float = 0.4,
 ) -> None:
+    pyxel.dither(dither)
     pyxel.rect(px_x, px_y, px_width, px_height, color)
+    pyxel.dither(1)

--- a/Gloomhaven/pyxel_ui/utils.py
+++ b/Gloomhaven/pyxel_ui/utils.py
@@ -1,4 +1,3 @@
-from .enums import Direction
 import pyxel
 
 
@@ -6,5 +5,12 @@ def draw_tile(x, y, img_bank, u, v, w, h, colkey=0):
     pyxel.blt(x, y, img_bank, u, v, w, h, colkey)
 
 
-def round_to_multiple(value, multiple):
+def round_down_to_nearest_multiple(value: int, multiple: int) -> int:
+    """
+    Rounds down the given value to the nearest multiple of `multiple`.
+
+    Example:
+        round_down_to_nearest_multiple(37, 10) -> 30
+        round_down_to_nearest_multiple(25, 7) -> 21
+    """
     return value // multiple * multiple


### PR DESCRIPTION
log and card view sections draws and redraws were causing a bit of lag. A few reasons is that we are making a lot of update log tasks even when log content has not changed. We've added a new setter for `LogView` so that we only clear, calculate font pixels, and draw when the log has changed. 

To make redraws much faster, we're saving the pixel data from each log and action card draw and have `redraw()` clear the screen and throw the pixels on their respective view sections. it's fast, but it can be faster! i'll look into storing pixel coordinates in a KD tree to be able to quickly retrieve pixels within a given box.

also added a grid under the mouse with adjustable dithering. I'm pushing what i have now, but i'm going to switch over to aligning the grid, which will mean auto-generating blank border view sections that can refresh themselves, thereby preventing the smears on the edges. 

once that's done, i'll align the grid with the map, make grid generation a map concern, and then translate map clicks turn into map coordinates which can be used to generate move commands.