### PR TITLE
adding view factory for borders

### DIFF
--- a/Gloomhaven/pyxel_ui/controllers/view_factory.py
+++ b/Gloomhaven/pyxel_ui/controllers/view_factory.py
@@ -1,0 +1,105 @@
+from typing import Optional
+
+from pyxel_ui.models.view_section import BorderView, ViewSection
+from pyxel_ui.models.view_params import ViewParams
+
+
+class ViewFactory:
+    def create_view_with_border(
+        self,
+        view_cls: ViewSection,
+        view_params: ViewParams,
+        borders: list[int] = [0, 0, 0, 0],
+    ) -> tuple[ViewSection, Optional[ViewSection]]:
+        """Create view and any related border views
+        Borders function like CSS box padding where the final size of all
+        views and their borders will match the size specified in view_params.
+
+        The view content will shrink to accommodate the borders. Bottom and top borders do
+        not extend beyond the sides of the content while left and right borders will extend
+        beyond the top/bottom to match borders. No voids at corners!
+
+        Args:
+            borders: top, right, bottom, left thickness in px
+        """
+        assert (
+            isinstance(borders, list)
+            and len(borders) == 4
+            and all(isinstance(x, int) for x in borders)
+        ), "Borders must be a list of exactly four integers"
+
+        top_px, right_px, bottom_px, left_px = borders
+        border_views = []
+        if top_px:
+            border_views.append(
+                BorderView(
+                    view_params.font,
+                    (
+                        view_params.start_pos[0] + left_px,
+                        view_params.start_pos[1],
+                    ),
+                    (
+                        view_params.bounding_coordinate[0] - right_px,
+                        view_params.start_pos[1] + top_px,
+                    ),
+                )
+            )
+        if bottom_px:
+            border_views.append(
+                BorderView(
+                    view_params.font,
+                    (
+                        view_params.start_pos[0] + left_px,
+                        view_params.bounding_coordinate[1] - bottom_px,
+                    ),
+                    (
+                        view_params.bounding_coordinate[0] - right_px,
+                        view_params.bounding_coordinate[1],
+                    ),
+                )
+            )
+        if left_px:
+            border_views.append(
+                BorderView(
+                    view_params.font,
+                    (
+                        view_params.start_pos[0],
+                        view_params.start_pos[1],
+                    ),
+                    (
+                        view_params.start_pos[0] + left_px,
+                        view_params.bounding_coordinate[1],
+                    ),
+                )
+            )
+        if right_px:
+            border_views.append(
+                BorderView(
+                    view_params.font,
+                    (
+                        view_params.bounding_coordinate[0] - right_px,
+                        view_params.start_pos[1],
+                    ),
+                    (
+                        view_params.bounding_coordinate[0],
+                        view_params.bounding_coordinate[1],
+                    ),
+                )
+            )
+
+        adjusted_params = view_params.to_kwargs()
+        adjusted_params.update(
+            {
+                "start_pos": (
+                    view_params.start_pos[0] + left_px,
+                    view_params.start_pos[1] + top_px,
+                ),
+                "bounding_coordinate": (
+                    view_params.bounding_coordinate[0] - right_px,
+                    view_params.bounding_coordinate[1] - bottom_px,
+                ),
+            }
+        )
+        new_view = view_cls(**adjusted_params)
+
+        return new_view, border_views

--- a/Gloomhaven/pyxel_ui/controllers/view_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/view_manager.py
@@ -2,12 +2,14 @@ import pyxel
 
 from typing import Optional
 
+from .view_factory import ViewFactory
 from pyxel_ui.constants import (
     BITS,
     FONT_PATH,
 )
 from pyxel_ui.models.font import PixelFont
 from pyxel_ui.views.sprite import SpriteManager
+from pyxel_ui.models.view_params import MapViewParams, ViewParams
 from pyxel_ui.models import view_section as view
 
 
@@ -20,49 +22,70 @@ class ViewManager:
         self.font = PixelFont(pyxel, f"../{FONT_PATH}")
         self.canvas_width = pyxel_width
         self.canvas_height = pyxel_height
-        self.initiative_bar_view = view.InitiativeBarView(
-            self.font,
-            start_pos=[self.view_border, self.view_border // 4],
-            bounding_coordinate=[BITS * 11, BITS],
+        self.view_factory = ViewFactory()
+        self.views = []
+
+        initiative_bar_width = 11
+        initiative_bar_view_params = ViewParams(
+            font=self.font,
+            start_pos=[0, 0],
+            bounding_coordinate=[BITS * initiative_bar_width, BITS],
         )
-        self.map_view = view.MapView(
-            self.font,
-            [
-                self.initiative_bar_view.start_pos[0],
-                self.initiative_bar_view.bounding_coordinate[1] + self.view_border,
+        self.initiative_bar_view, bar_borders = (
+            self.view_factory.create_view_with_border(
+                view.InitiativeBarView, initiative_bar_view_params, [4, 0, 0, 10]
+            )
+        )
+        self.views.extend([self.initiative_bar_view, *bar_borders])
+
+        map_view_params = MapViewParams(
+            font=self.font,
+            start_pos=[
+                0,
+                BITS,
             ],
-            [
+            bounding_coordinate=[
                 self.initiative_bar_view.bounding_coordinate[0],
-                BITS * 11 + self.view_border * 2,
+                BITS * 12,
             ],
             floor_color_map=floor_color_map,
             wall_color_map=wall_color_map,
         )
-        self.log_view = view.LogView(
-            self.font,
-            [
-                self.initiative_bar_view.bounding_coordinate[0],
-                self.initiative_bar_view.start_pos[1],
+        self.map_view, map_borders = self.view_factory.create_view_with_border(
+            view.MapView, map_view_params, [10, 10, 0, 10]
+        )
+        self.views.extend([self.map_view, *map_borders])
+
+        log_view_params = ViewParams(
+            font=self.font,
+            start_pos=[
+                initiative_bar_width * BITS,
+                0,
             ],
-            [
+            bounding_coordinate=[
                 self.canvas_width,
-                self.map_view.bounding_coordinate[1] + self.view_border,
+                self.map_view.bounding_coordinate[1],
             ],
         )
-        self.action_card_view = view.ActionCardView(
-            self.font,
-            [
-                self.map_view.start_pos[0],
-                self.map_view.bounding_coordinate[1] + self.view_border,
-            ],
-            [self.canvas_width, self.canvas_height],
+        self.log_view, log_borders = self.view_factory.create_view_with_border(
+            view.LogView, log_view_params, [4, 0, 0, 0]
         )
-        self.views = [
-            self.initiative_bar_view,
-            self.map_view,
-            self.log_view,
-            self.action_card_view,
-        ]
+        self.views.extend([self.log_view, *log_borders])
+
+        action_card_view_params = ViewParams(
+            font=self.font,
+            start_pos=[
+                0,
+                self.map_view.bounding_coordinate[1],
+            ],
+            bounding_coordinate=[self.canvas_width, self.canvas_height],
+        )
+        self.action_card_view, action_card_borders = (
+            self.view_factory.create_view_with_border(
+                view.ActionCardView, action_card_view_params
+            )
+        )
+        self.views.extend([self.action_card_view, *action_card_borders])
 
     def update_log(self, log: list[str]):
         # note: drawable set in update_round_turn()
@@ -101,10 +124,10 @@ class ViewManager:
         self.action_card_view.draw()
 
     def update_map(
-        self, 
-        valid_floor_coordinates: list[tuple[int, int]], 
+        self,
+        valid_floor_coordinates: list[tuple[int, int]],
         floor_color_map=[],
-        wall_color_map=[]
+        wall_color_map=[],
     ) -> None:
         if valid_floor_coordinates:
             self.map_view.drawable = True
@@ -164,8 +187,8 @@ class ViewManager:
         px_x -= self.map_view.start_pos[0]
         px_y -= self.map_view.start_pos[1]
         # figure out the tile number (not px)
-        x_num = px_x/self.map_view.tile_width_px
-        y_num = px_y/self.map_view.tile_height_px
+        x_num = px_x / self.map_view.tile_width_px
+        y_num = px_y / self.map_view.tile_height_px
         if (x_num, y_num) in self.map_view.valid_map_coordinates:
             return True
         return False

--- a/Gloomhaven/pyxel_ui/enums.py
+++ b/Gloomhaven/pyxel_ui/enums.py
@@ -1,13 +1,6 @@
 from enum import Enum, auto
 
 
-class Direction(Enum):
-    NORTH = auto()
-    WEST = auto()
-    EAST = auto()
-    SOUTH = auto()
-
-
 class AnimationFrame(Enum):
     NORTH = auto()
     WEST = auto()
@@ -15,3 +8,10 @@ class AnimationFrame(Enum):
     SOUTH = auto()
     IDLE_1 = auto()
     IDLE_2 = auto()
+
+
+class Direction(Enum):
+    NORTH = auto()
+    WEST = auto()
+    EAST = auto()
+    SOUTH = auto()

--- a/Gloomhaven/pyxel_ui/models/view_params.py
+++ b/Gloomhaven/pyxel_ui/models/view_params.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+
+from .font import PixelFont
+
+
+@dataclass
+class ViewParams:
+    font: PixelFont
+    start_pos: tuple[int, int]
+    bounding_coordinate: tuple[int, int]
+
+    def to_kwargs(self):
+        return {
+            "font": self.font,
+            "start_pos": self.start_pos,
+            "bounding_coordinate": self.bounding_coordinate,
+        }
+
+
+@dataclass
+class MapViewParams(ViewParams):
+    floor_color_map: list[tuple[int, int]] = field(default_factory=list)
+    wall_color_map: list[tuple[int, int]] = field(default_factory=list)
+
+    def to_kwargs(self):
+        return {
+            "font": self.font,
+            "start_pos": self.start_pos,
+            "bounding_coordinate": self.bounding_coordinate,
+            "floor_color_map": self.floor_color_map,
+            "wall_color_map": self.wall_color_map,
+        }

--- a/Gloomhaven/pyxel_ui/models/view_section.py
+++ b/Gloomhaven/pyxel_ui/models/view_section.py
@@ -48,6 +48,14 @@ class ViewSection(abc.ABC):
         pass
 
 
+class BorderView(ViewSection):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def draw(self) -> None:
+        self.clear_bounds()
+
+
 class LogView(ViewSection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/Gloomhaven/pyxel_ui/utils.py
+++ b/Gloomhaven/pyxel_ui/utils.py
@@ -8,6 +8,7 @@ def draw_tile(x, y, img_bank, u, v, w, h, colkey=0):
 def round_down_to_nearest_multiple(value: int, multiple: int, offset: int) -> int:
     """
     Rounds down the given value to the nearest multiple of `multiple`.
+    Can offset grid location to account for border.
 
     Example:
         round_down_to_nearest_multiple(37, 10) -> 30


### PR DESCRIPTION
This introduces a new pattern of creating view sections within the view manager that creates new BorderViews which fill in blank spots that acted as buffers between views. The borders behave like CSS box buffers where specifying borders shrinks the content, creating BorderViews to fill the gaps. Unlike blank spaces, border views can be refreshed to prevent cursor smearing.

Grid highlighting still functions, but it seems like offsetting it by anything other than 10 causes the check to not work. We'll have to move grid concerns into the map view, but we'll worry about that after we've enabled mouse movement.

We still need to eliminate cursor smear when you go along the boundaries between views, which we can do for now by treating the cursor as a box rather than a point. Shouldn't be too hard, but it might cause a slight dip in performance. But that's fine. 