### PR TITLE
enable mouse movement

### DIFF
--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -317,8 +317,8 @@ class Board:
             closed.add(current)
 
             for direction in directions:
-                new_row = current[0] + direction[0]
-                new_col = current[1] + direction[1]
+                new_row = int(current[0] + direction[0])
+                new_col = int(current[1] + direction[1])
                 new_pos = (new_row, new_col)
                 if new_pos not in closed and (
                     self.is_legal_move(new_row, new_col) or new_pos == end

--- a/Gloomhaven/backend/models/campaign_manager.py
+++ b/Gloomhaven/backend/models/campaign_manager.py
@@ -4,6 +4,7 @@ from itertools import count
 import pickle
 import os
 
+from pyxel_ui.models.pyxel_action_queue import PyxelActionQueue
 from pyxel_ui.models.pyxel_task_queue import PyxelTaskQueue
 from pyxel_ui.engine import PyxelEngine
 from backend.models.game_loop import GameLoop
@@ -14,7 +15,8 @@ import backend.models.character as character
 import backend.models.agent as agent
 from backend.utils.utilities import GameState
 from backend.utils.utilities import get_campaign_filenames
-from backend.utils.config import SAVE_FILE_DIR 
+from backend.utils.config import SAVE_FILE_DIR
+
 
 @dataclass
 class CampaignState:
@@ -25,15 +27,18 @@ class CampaignState:
     all_ai_mode: bool
     id_gen_start: int
 
+
 class Campaign:
-    '''
+    """
     a campaign is a series of games, each of which has level metadata
-    '''
+    """
+
     def __init__(self, disp: Display, num_players_default: int, all_ai_mode: bool):
         self.current_level: Level
-        shared_action_queue = PyxelTaskQueue()
-        self.pyxel_view = PyxelEngine(shared_action_queue)
-        self.pyxel_manager = PyxelManager(shared_action_queue)
+        shared_task_queue = PyxelTaskQueue()
+        shared_action_queue = PyxelActionQueue()
+        self.pyxel_view = PyxelEngine(shared_task_queue, shared_action_queue)
+        self.pyxel_manager = PyxelManager(shared_task_queue, shared_action_queue)
         self.disp = disp
         self.num_players = num_players_default
         self.all_ai_mode = all_ai_mode
@@ -45,19 +50,18 @@ class Campaign:
 
     def load_campaign(self, filename):
         # get the data needed to recreate the campaign
-        with open(SAVE_FILE_DIR+filename, 'rb') as f:
+        with open(SAVE_FILE_DIR + filename, "rb") as f:
             campaign_state = pickle.load(f)
 
         # recreate it
         self.initialized = True
         self.id_generator = count(start=campaign_state.id_gen_start)
         self.make_levels()
-        self.levels = self.levels[-campaign_state.remaining_levels:]
+        self.levels = self.levels[-campaign_state.remaining_levels :]
         self.all_ai_mode = campaign_state.all_ai_mode
         self.num_players = campaign_state.num_players
         self.player_chars = self.load_player_characters(
-            campaign_state.player_names,
-            campaign_state.player_classes
+            campaign_state.player_names, campaign_state.player_classes
         )
 
     def start_campaign(self):
@@ -76,22 +80,22 @@ class Campaign:
     def run_level(self, level: Level):
         self.current_level = level
         if not self.all_ai_mode:
-            self.disp.print_message(message=self.current_level.pre_level_text, clear_display=True)
-            self.disp.get_user_input(
-                prompt="Hit enter to continue\n"
+            self.disp.print_message(
+                message=self.current_level.pre_level_text, clear_display=True
             )
+            self.disp.get_user_input(prompt="Hit enter to continue\n")
         self.pyxel_manager.set_level_map_colors(
-            self.current_level.floor_color_map,
-            self.current_level.wall_color_map
+            self.current_level.floor_color_map, self.current_level.wall_color_map
         )
         game = GameLoop(
-            self.disp, 
-            self.num_players, 
-            self.all_ai_mode, 
-            self.pyxel_manager, 
+            self.disp,
+            self.num_players,
+            self.all_ai_mode,
+            self.pyxel_manager,
             self.current_level,
             self.id_generator,
-            self.player_chars)
+            self.player_chars,
+        )
         return game.start()
 
     def run_levels(self):
@@ -101,30 +105,39 @@ class Campaign:
             # if you don't win the level, end here
             if output != GameState.WIN:
                 return
-            
+
             self.offer_to_save_campaign()
 
     def set_num_players(self):
         if not self.all_ai_mode:
             self.num_players = int(
-                    self.disp.get_user_input(
-                        "Let's set up the game. How many players are playing? Type 1, 2, or 3.", ["1", "2", "3"]
-                    )
+                self.disp.get_user_input(
+                    "Let's set up the game. How many players are playing? Type 1, 2, or 3.",
+                    ["1", "2", "3"],
                 )
+            )
 
     def select_player_character(self, player_num):
         # don't get input for all ai mode
         if self.all_ai_mode:
             return self.available_chars.pop()
-        
-        self.disp.print_message(f"It's time to pick Player {player_num}'s character. Here are your options:\n",True)
+
+        self.disp.print_message(
+            f"It's time to pick Player {player_num}'s character. Here are your options:\n",
+            True,
+        )
         # print the backstory for every available char
         for i, char in enumerate(self.available_chars):
-            self.disp.print_message(f"{i}: {char.__class__.__name__}",False)
+            self.disp.print_message(f"{i}: {char.__class__.__name__}", False)
             self.disp.print_message(f"{char.backstory}\n", False)
 
         # let user pick a character
-        player_char_num = int(self.disp.get_user_input(prompt="Type the number of the character you want to play. ", valid_inputs=[f"{j}" for j,_ in enumerate(self.available_chars)]))
+        player_char_num = int(
+            self.disp.get_user_input(
+                prompt="Type the number of the character you want to play. ",
+                valid_inputs=[f"{j}" for j, _ in enumerate(self.available_chars)],
+            )
+        )
         player_char = self.available_chars.pop(player_char_num)
 
         # reset default name if player provides a name
@@ -137,13 +150,28 @@ class Campaign:
     def set_up_player_chars(self):
         emojis = ["🧙", "🕺", "🐣", "🐣"]
         default_names = ["Happy", "Glad", "Jolly", "Cheery"]
-        char_classes = [character.Monk, character.Necromancer, character.Miner, character.Wizard]
-        
+        char_classes = [
+            character.Monk,
+            character.Necromancer,
+            character.Miner,
+            character.Wizard,
+        ]
+
         # set up characters players can choose from
         for char_class, emoji, default_name in zip(char_classes, emojis, default_names):
             player_agent = agent.Ai() if self.all_ai_mode else agent.Human()
-            self.available_chars.append(char_class(default_name, self.disp, emoji, player_agent, char_id = next(self.id_generator), is_monster=False, log=self.pyxel_manager.log))
-        
+            self.available_chars.append(
+                char_class(
+                    default_name,
+                    self.disp,
+                    emoji,
+                    player_agent,
+                    char_id=next(self.id_generator),
+                    is_monster=False,
+                    log=self.pyxel_manager.log,
+                )
+            )
+
         for i in range(self.num_players):
             self.player_chars.append(self.select_player_character(i))
 
@@ -152,24 +180,38 @@ class Campaign:
 
     def load_player_characters(self, player_names, char_classes):
         emojis = ["🧙", "🕺", "🐣", "🐣"]
-        
-        # recreate the same characters 
+
+        # recreate the same characters
         player_chars = []
-        for char_class_name, player_name, emoji in zip(char_classes, player_names, emojis):
+        for char_class_name, player_name, emoji in zip(
+            char_classes, player_names, emojis
+        ):
             char_class = getattr(character, char_class_name)
             player_agent = agent.Ai() if self.all_ai_mode else agent.Human()
-            player_chars.append(char_class(player_name, self.disp, emoji, player_agent, char_id = next(self.id_generator), is_monster=False, log=self.pyxel_manager.log))
+            player_chars.append(
+                char_class(
+                    player_name,
+                    self.disp,
+                    emoji,
+                    player_agent,
+                    char_id=next(self.id_generator),
+                    is_monster=False,
+                    log=self.pyxel_manager.log,
+                )
+            )
         return player_chars
-    
+
     def offer_to_save_campaign(self):
-        user_input = self.disp.get_user_input("Would you like to save your progress? Type (y)es or (n)o. ",["y","n"])
+        user_input = self.disp.get_user_input(
+            "Would you like to save your progress? Type (y)es or (n)o. ", ["y", "n"]
+        )
         should_save = True if user_input == "y" else False
         if should_save:
             self.save_campaign()
 
     def get_unused_filename(self):
         file_names = get_campaign_filenames()
-        i=0
+        i = 0
         filename = f"campaign_{i}.pickle"
         while True:
             if filename in file_names:
@@ -178,19 +220,21 @@ class Campaign:
             else:
                 break
         return filename
-    
+
     def save_campaign(self):
         # Create a simple dict with just the essential data
         campaign_state = CampaignState(
             remaining_levels=len(self.levels),
-            player_classes=[type(char).__name__ for char in self.player_chars],  
+            player_classes=[type(char).__name__ for char in self.player_chars],
             player_names=[char.name for char in self.player_chars],
             num_players=self.num_players,
             all_ai_mode=self.all_ai_mode,
-            id_gen_start=next(self.id_generator)
+            id_gen_start=next(self.id_generator),
         )
         filename = self.get_unused_filename()
         os.makedirs(SAVE_FILE_DIR, exist_ok=True)
-        with open(SAVE_FILE_DIR+filename, 'wb') as f:
+        with open(SAVE_FILE_DIR + filename, "wb") as f:
             pickle.dump(campaign_state, f)
-        self.disp.get_user_input(f"Successfully saved {filename}. Hit enter to continue. ")
+        self.disp.get_user_input(
+            f"Successfully saved {filename}. Hit enter to continue. "
+        )

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -119,10 +119,11 @@ class GameLoop:
         get_input = True
         try:
             # Taking over user input with check on action queue
+            print(f"{acting_character=}")
             while get_input:
                 if not self.pyxel_manager.shared_action_queue.is_empty():
                     action = self.pyxel_manager.shared_action_queue.dequeue()
-                    action.perform()  # make these async?
+                    action.perform(self.board, acting_character)  # make these async?
 
             if not acting_character.team_monster:
                 self.pyxel_manager.load_action_cards(

--- a/Gloomhaven/pyxel_ui/engine.py
+++ b/Gloomhaven/pyxel_ui/engine.py
@@ -26,7 +26,6 @@ from .utils import round_down_to_nearest_multiple
 class PyxelEngine:
     def __init__(self, task_queue: PyxelTaskQueue, action_queue: PyxelActionQueue):
         self.current_task = None
-        self.is_board_initialized = False
 
         self.last_mouse_pos = (-1, -1)
 
@@ -124,8 +123,9 @@ class PyxelEngine:
         if pyxel.btnp(pyxel.MOUSE_BUTTON_LEFT):
             if self.mouse_tile_pos:
                 tile_pos_x, tile_pos_y = self.mouse_tile_pos
-                print(f"{tile_pos_x}, {tile_pos_y}")
-                move_action = MoveAction(1, (tile_pos_x, tile_pos_y))
+                # BUG: location seems to be relative to character starting position so
+                # the target location will always be off by some amount, e.g. always 2 over.
+                move_action = MoveAction(1, (int(tile_pos_y), int(tile_pos_x)))
                 self.action_queue.enqueue(move_action)
 
     def draw(self):

--- a/Gloomhaven/pyxel_ui/models/action.py
+++ b/Gloomhaven/pyxel_ui/models/action.py
@@ -1,11 +1,16 @@
-from dataclasses import dataclass
 import abc
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from backend.models.board import Board
+    from backend.models.character import Character
 
 
 @dataclass
 class Action(abc.ABC):
     @abc.abstractmethod
-    def perform(self):
+    def perform(self, backend_engine: "Board"):
         pass
 
 
@@ -20,5 +25,8 @@ class MoveAction(Action):
     character_id: int
     destination_map_tile_coord: tuple[int, int]
 
-    def perform(self):
-        print(f"moving to {self.destination_map_tile_coord}")
+    def perform(self, backend_engine: "Board", acting_character: "Character"):
+        print(f"{self.destination_map_tile_coord=}")
+        backend_engine.move_character_toward_location(
+            acting_character, self.destination_map_tile_coord, 99
+        )


### PR DESCRIPTION
this enables mouse movement which is only available by running pyxel_action_queue.py

The thought here is that when it's a player character's turn, we send a task to enable user input on Pyxel along with valid actions the player can take. the backend will then go into a while loop, checking the `PyxelActionQueue` for new actions. the `Action` object's `perform()` method takes in the `Board` and `acting_character` to do whatever it has to do.

Movement has a bug. It looks like there's something making target locations and actual character locations off by some amount. Maybe some relative difference is baked into all movement for the entire game? I also noticed that we're not consistent with board tile X and Y. I have it as row, col on the FE and i think it's flipped on the BE