### PR TITLE
find all reachable path BE

### DIFF
--- a/Gloomhaven/backend/utils/utilities.py
+++ b/Gloomhaven/backend/utils/utilities.py
@@ -1,17 +1,22 @@
 from functools import partial
 from enum import Enum, auto
 from pathlib import Path
-from backend.utils.config import SAVE_FILE_DIR 
+from backend.utils.config import SAVE_FILE_DIR
+
 
 def make_multiply_modifier(multiplier: int, multiplier_text: str) -> tuple:
     def multiply(x, y):
         return x * y
+
     return (partial(multiply, multiplier), multiplier_text)
+
 
 def make_additive_modifier(modifier_num) -> tuple:
     def add(x, y):
         return x + y
+
     return (partial(add, modifier_num), f"{modifier_num:+d}")
+
 
 class GameState(Enum):
     START = auto()
@@ -20,8 +25,24 @@ class GameState(Enum):
     GAME_OVER = auto()
     EXHAUSTED = auto()
 
+
 def get_campaign_filenames():
-    return [p.name for p in list(Path(SAVE_FILE_DIR).glob("*.pickle")) if "game_" in p.name]
+    return [
+        p.name for p in list(Path(SAVE_FILE_DIR).glob("*.pickle")) if "game_" in p.name
+    ]
+
 
 class DieAndEndTurn(Exception):
     pass
+
+
+directions = [
+    (1, 0),  # Down
+    (0, 1),  # Right
+    (-1, 0),  # Up
+    (0, -1),  # Left
+    (-1, 1),  # NE
+    (1, 1),  # SE
+    (1, -1),  # SW
+    (-1, -1),  # NW
+]


### PR DESCRIPTION
when it's a player's turn to move, we want to display all tiles that can be reached during their turn. when the the player hovers over a reachable tile, we should display the path their character will take to reach that tile.

we will support this with a new `Board` method, `find_all_reachable_paths()`, which will perform a BFS to find all reachable positions and then iterate over these positions, passing them to `get_shortest_valid_path(). this then returns both a list of reachable positions and a dict of shortest valid paths to get to each of those positions, keyed by their end position.

we should also support jumps, but i think a separate method, something like `find_all_jumpable_paths` would work the best.

also refactored `get_shortest_valid_path()` a bit to remove the clunky iteration.