### PR TITLE
adding Task processing and range + path highlighting

### DIFF
--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -317,10 +317,18 @@ class Human(Agent):
                 return
             current_loc = board.find_location_of_target(char)
             # only allow user to pick a square in range
+
+            # send reachable positions and the shortest valid paths to get to them.
+            reachable_positions, reachable_paths = board.find_all_reachable_paths(
+                current_loc, remaining_movement
+            )
+
             new_row, new_col = char.pyxel_manager.get_user_input(
                 prompt=prompt + f"\nMovement remaining: {remaining_movement}",
                 is_mouse=True,
                 client_id=client_id,
+                reachable_positions=reachable_positions,
+                reachable_paths=reachable_paths,
             )
             # we ask them to click on their character if they want to finish their movement
             if current_loc == (new_row, new_col):

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -260,6 +260,8 @@ class Board:
         """
         Finds all positions reachable within the movement range and the shortest path to each position.
 
+        NOTE: All positions are flipped and then normalized!
+
         Args:
             start: Starting position as (row, col)
             num_moves: Maximum number of moves allowed
@@ -319,7 +321,22 @@ class Board:
             ):
                 reachable_paths[end_pos] = path
 
-        return list(reachable_positions), reachable_paths
+        # Flip then normalize all positions
+        reachable_positions = [
+            pos
+            for x, y in reachable_positions
+            for pos in [self.pyxel_manager.normalize_coordinate((y, x))]
+        ]
+        reachable_paths = {
+            self.pyxel_manager.normalize_coordinate((k_y, k_x)): [
+                pos
+                for x, y in v
+                for pos in [self.pyxel_manager.normalize_coordinate((y, x))]
+            ]
+            for (k_x, k_y), v in reachable_paths.items()
+        }
+
+        return reachable_positions, reachable_paths
 
     def get_shortest_valid_path(
         self,

--- a/Gloomhaven/backend/models/pyxel_backend.py
+++ b/Gloomhaven/backend/models/pyxel_backend.py
@@ -188,11 +188,21 @@ class PyxelManager:
         self.server_client.post_task(json_task, client_id)
 
     def get_user_input(
-        self, prompt, valid_inputs=None, client_id="ALL_FRONTEND", is_mouse=False
+        self,
+        prompt,
+        valid_inputs=None,
+        client_id="ALL_FRONTEND",
+        is_mouse=False,
+        reachable_positions=None,
+        reachable_paths=None,
     ):
         # tell client to get user input
         task_class = tasks.MouseInputTask if is_mouse else tasks.InputTask
-        task = task_class(prompt)
+        task = task_class(
+            prompt=prompt,
+            reachable_positions=reachable_positions,
+            reachable_paths=reachable_paths,
+        )
 
         self.jsonify_and_send_task(task, client_id)
         # get input back

--- a/Gloomhaven/frontend_main.py
+++ b/Gloomhaven/frontend_main.py
@@ -5,7 +5,7 @@ from backend.utils.config import TEXT_WIDTH
 
 def main(dev_mode=False):
     host = "13.59.128.25"
-    # host = "localhost"
+
     if dev_mode:
         port = "8000"
         host = "localhost"

--- a/Gloomhaven/frontend_main.py
+++ b/Gloomhaven/frontend_main.py
@@ -5,6 +5,7 @@ from backend.utils.config import TEXT_WIDTH
 
 def main(dev_mode=False):
     host = "13.59.128.25"
+    # host = "localhost"
     if dev_mode:
         port = "8000"
         host = "localhost"

--- a/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
@@ -7,18 +7,25 @@ from pyxel_ui.utils import round_down_to_nearest_multiple
 class UserInputManager:
     def __init__(self, view_manager, server_client):
         self.view_manager = view_manager
+
         self.accept_keyboard_input = False
         self.accept_mouse_input = False
-        self.input = ""
-        self.prompt = ""
-        self.server_client = server_client
-        self.mouse_tile_pos = None
-        self.last_mouse_pos = (-1, -1)
-        self.draw_shape_with_cursor = False
         self.cursor_shape_offsets = []
         self.default_grid_color = 3
+        self.draw_shape_with_cursor = False
         self.grid_color = self.default_grid_color
+        self.input = ""
+        self.last_mouse_pos = (-1, -1)
+        self.mouse_tile_pos = None
+        self.prompt = ""
+        self.server_client = server_client
         self.valid_starting_squares = []
+
+        self.reachable_positions: list[tuple[int, int]] = []
+        # The coordinates represented in these attributes have been converted from
+        # map tile to pixel with view border offsets applied.
+        self.reachable_positions_px: list[tuple[int, int]] = []
+        self.reachable_paths_px: dict[tuple[int, int], list[tuple[int, int]]] = {}
 
     def update(self):
         if pyxel.btnp(pyxel.KEY_ESCAPE):
@@ -71,7 +78,15 @@ class UserInputManager:
             self.view_manager.scroll_carousel_left()
 
         if self.accept_mouse_input:
-            self.print_personal_log(self.input)
+            for pos_x, pos_y in self.reachable_positions_px:
+                self.view_manager.draw_grid(
+                    pos_x, pos_y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, color=5
+                )
+            if self.mouse_tile_pos and self.mouse_tile_pos in self.reachable_positions:
+                for path_x, path_y in self.reachable_paths_px[self.mouse_tile_pos]:
+                    self.view_manager.draw_grid(
+                        path_x, path_y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, color=7
+                    )
             if pyxel.btnp(pyxel.MOUSE_BUTTON_LEFT) and self.mouse_tile_pos:
                 tile_pos_x, tile_pos_y = self.mouse_tile_pos
                 # BUG: location seems to be relative to character starting position so
@@ -123,6 +138,8 @@ class UserInputManager:
     def return_input_to_server(self):
         self.server_client.post_user_input(self.input)
 
+    # nit: this method doesn't actually get mouse input, maybe
+    # rename to something like enable_mouse_input?
     def get_mouse_input(self, prompt):
         self.input = ""
         self.accept_mouse_input = True
@@ -138,3 +155,25 @@ class UserInputManager:
             self.view_manager.draw_grid(
                 x, y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, color
             )
+
+    def set_reachable_values(
+        self,
+        reachable_positions: list[tuple[int, int]],
+        reachable_paths: dict[tuple[int, int], list[tuple[int, int]]],
+    ) -> None:
+        # We are flipping x and y after unpacking. This needs to be resolved upstream.
+        self.reachable_positions = [
+            (pos_y, pos_x) for pos_x, pos_y in reachable_positions
+        ]
+        self.reachable_positions_px = [
+            self.view_manager.get_pixel_pos_for_map_tile(pos_y, pos_x)
+            for pos_x, pos_y in reachable_positions
+        ]
+
+        self.reachable_paths_px = {
+            (end_pos_y, end_pos_x): [
+                self.view_manager.get_pixel_pos_for_map_tile(p_y, p_x)
+                for p_x, p_y in paths
+            ]
+            for (end_pos_x, end_pos_y), paths in reachable_paths.items()
+        }

--- a/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
@@ -161,19 +161,17 @@ class UserInputManager:
         reachable_positions: list[tuple[int, int]],
         reachable_paths: dict[tuple[int, int], list[tuple[int, int]]],
     ) -> None:
-        # We are flipping x and y after unpacking. This needs to be resolved upstream.
-        self.reachable_positions = [
-            (pos_y, pos_x) for pos_x, pos_y in reachable_positions
-        ]
+        self.reachable_positions = reachable_positions
+
+        # Convert map tile coords to pixel coords
         self.reachable_positions_px = [
-            self.view_manager.get_pixel_pos_for_map_tile(pos_y, pos_x)
+            self.view_manager.get_pixel_pos_for_map_tile(pos_x, pos_y)
             for pos_x, pos_y in reachable_positions
         ]
-
         self.reachable_paths_px = {
-            (end_pos_y, end_pos_x): [
-                self.view_manager.get_pixel_pos_for_map_tile(p_y, p_x)
-                for p_x, p_y in paths
+            end_pos: [
+                self.view_manager.get_pixel_pos_for_map_tile(pos_x, pos_y)
+                for pos_x, pos_y in paths
             ]
-            for (end_pos_x, end_pos_y), paths in reachable_paths.items()
+            for end_pos, paths in reachable_paths.items()
         }

--- a/Gloomhaven/pyxel_ui/controllers/view_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/view_manager.py
@@ -14,10 +14,8 @@ from pyxel_ui.models import view_section as view
 
 
 class ViewManager:
-    def __init__(
-        self, pyxel_width, pyxel_height, floor_color_map=[], wall_color_map=[]
-    ):
-        self.view_border = 10
+    def __init__(self, pyxel_width: int, pyxel_height: int):
+        self.view_border: int = 10
         self.sprite_manager = SpriteManager()
         self.font = PixelFont(pyxel, f"../{FONT_PATH}")
         self.canvas_width = pyxel_width
@@ -255,8 +253,9 @@ class ViewManager:
         px_width: int,
         px_height: int,
         color: int = 3,
+        **kwargs,
     ) -> None:
-        view.draw_grid(px_x, px_y, px_width, px_height, color)
+        view.draw_grid(px_x, px_y, px_width, px_height, color=color, **kwargs)
 
     def draw_whole_game(self):
         for v in self.views:
@@ -276,6 +275,24 @@ class ViewManager:
         if (x_num, y_num) in self.map_view.valid_map_coordinates:
             return (x_num, y_num)
         return None
+
+    def get_pixel_pos_for_map_tile(
+        self,
+        tile_x: int,
+        tile_y: int,
+        offset_x: int = 0,
+        offset_y: int = 0,
+    ) -> tuple[int, int]:
+        """Converts the tile numbers into pixel coordinates representing the top-left corner
+        in the tile.
+        """
+        px_x = tile_x * self.map_view.tile_width_px
+        px_y = tile_y * self.map_view.tile_height_px
+
+        px_x += self.map_view.start_pos[0] + offset_x
+        px_y += self.map_view.start_pos[1] + offset_y
+
+        return (px_x, px_y)
 
     def _get_active_carousel(self):
         active_carousel = [

--- a/Gloomhaven/pyxel_ui/engine.py
+++ b/Gloomhaven/pyxel_ui/engine.py
@@ -43,6 +43,7 @@ class PyxelEngine:
 
         self.view_manager = ViewManager(DEFAULT_PYXEL_WIDTH, DEFAULT_PYXEL_HEIGHT)
         # self.mouse_tile_pos = None
+        # maybe change this to input_manager?
         self.keyboard_manager = UserInputManager(self.view_manager, self.server_client)
         self.loop_num = 1
 

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -210,6 +210,8 @@ class InputTask(Task):
     """
 
     prompt: str
+    reachable_positions: Optional[list[tuple[int, int]]] = None
+    reachable_paths: Optional[dict[tuple[int, int], list[tuple[int, int]]]] = None
 
     def perform(self, view_manager, user_input_manager):
         user_input_manager.get_keyboard_input(self.prompt)
@@ -234,9 +236,15 @@ class MouseInputTask(Task):
     """
 
     prompt: str
+    reachable_positions: Optional[list[tuple[int, int]]] = None
+    reachable_paths: Optional[dict[tuple[int, int], list[tuple[int, int]]]] = None
 
     def perform(self, view_manager, user_input_manager):
         user_input_manager.get_mouse_input(self.prompt)
+        if self.reachable_positions and self.reachable_paths:
+            user_input_manager.set_reachable_values(
+                self.reachable_positions, self.reachable_paths
+            )
 
 
 # @dataclass


### PR DESCRIPTION
This will now highlight the reachable position and path data from #81 . I added this into the `accept_mouse_input` condition which will conveniently hide the highlights when the user is not able to move. Since the `draw_grid()` method operates on pixel coordinates, we convert all position and path data into pixel coordinates, though the dict still keys off of their map tile equivalents.

We still have to flip x and y coordinates when pushing positions between the FE and BE and that should be addressed at some time. For now I'm flipping these particular positions at `UserInputManager.set_reachable_values()`. 

Now we'll have to add jump ranges and we should be all set here.

Oh, we should chat about colors to use here. 

Also:
![pyxel path options](https://github.com/user-attachments/assets/30b2aef7-047f-4bf0-8067-f76f157e2ee1)

We only provide one valid path per end position, and if there are multiple valid paths of equal length, it will take the one that it tries first and this is tied to the order of directions in `backend.utils.utilities.directions`. This can lead to awkward movements like the ones you see above, which shouldn't really be a problem unless it forces a character to go through an unnecessary obstacle. But I don't think even that's a huge issue since automatic trap avoidance would kinda take away from the concept of a trap. A skilled player will micro their character around obstacles.

