### PR TITLE
Throwing area attacks

### DIFF
--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -72,7 +72,7 @@ class ElementAreaEffectWithTarget(ActionStep):
 
     def perform(self, board, attacker, round_num):
         target_row, target_col = attacker.select_board_square_target(
-            board, self.att_range
+            board, self.att_range, self.shape
         )
         # if we don't get a target, return
         if target_row is None:

--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import abc
 import random
 from functools import partial
-from typing import Type
+from typing import Type, Optional
 
 from . import obstacle
 from ..utils import utilities as utils
@@ -66,23 +66,40 @@ class SingleTargetAttack(ActionStep):
 @dataclass
 class ElementAreaEffectWithTarget(ActionStep):
     shape: set
-    element_type: Type[obstacle.TerrainObject]
     att_range: int
+    damage: Optional[int] = None
+    element_type: Optional[Type[obstacle.TerrainObject]] = None
 
     def perform(self, board, attacker, round_num):
         target_row, target_col = attacker.select_board_square_target(
             board, self.att_range
         )
-
-        if target_row is not None:
-            board.add_effect_to_terrain_for_attack(
-                self.element_type, target_row, target_col, self.shape
-            )
-        else:
+        # if we don't get a target, return
+        if target_row is None:
             board.pyxel_manager.log.append("No target in range")
+            return
+
+        # if we're given an element, add elements to board
+        if self.element_type:
+            board.add_effect_to_terrain_for_attack(
+                self.element_type,
+                target_row,
+                target_col,
+                self.shape,
+            )
+
+        # if we're given damage, perform a damage attack
+        if self.damage:
+            attack_coords = [
+                (target_row + coordinate[0], target_col + coordinate[1])
+                for coordinate in self.shape
+            ]
+            board.attack_area(attacker, attack_coords, self.damage)
 
     def __str__(self):
-        return f"{self.element_type.__name__} Attack, Targets Opponent @\nRange {self.att_range} and Shape:\n{shapes.print_shape(self.shape)}"
+        attack_type = f"{self.element_type.__name__} " if self.element_type else ""
+        damage_str = f" for {self.damage} Damage" if self.damage else ""
+        return f"{attack_type}Attack{damage_str}, Targets Opponent @\nRange {self.att_range} and Shape:\n{shapes.print_shape(self.shape)}"
 
     def perform_string(self, attacker):
         return f"{attacker.name} throws {self.element_type.__name__}"

--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -70,12 +70,13 @@ class ElementAreaEffectWithTarget(ActionStep):
     att_range: int
 
     def perform(self, board, attacker, round_num):
-        target = select_in_range_target(board, attacker, self.att_range)
+        target_row, target_col = attacker.select_board_square_target(
+            board, self.att_range
+        )
 
-        if target is not None:
-            row, col = board.find_location_of_target(target)
+        if target_row is not None:
             board.add_effect_to_terrain_for_attack(
-                self.element_type, row, col, self.shape
+                self.element_type, target_row, target_col, self.shape
             )
         else:
             board.pyxel_manager.log.append("No target in range")

--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -477,8 +477,6 @@ class PushAllEnemies(ActionStep):
     att_range: int
 
     def perform(self, board, attacker, round_num):
-        from .agent import Human
-
         enemies = board.find_in_range_opponents_or_allies(
             attacker, self.att_range, opponents=True
         )
@@ -486,16 +484,15 @@ class PushAllEnemies(ActionStep):
             board.pyxel_manager.log.append("No one in range to push")
             return
 
-        is_legal_push_check = partial(
-            check_if_legal_push, board.find_location_of_target(attacker), board
-        )
+        attacker_loc = board.find_location_of_target(attacker)
+        is_legal_push_check = partial(check_if_legal_push, attacker_loc, board)
 
         for enemy in enemies:
             board.pyxel_manager.log.append(f"Pushing {enemy.name}")
 
             attacker.agent.move_other_character(
                 enemy,
-                board.find_location_of_target(attacker),
+                attacker_loc,
                 self.squares,
                 False,
                 board,

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -375,7 +375,9 @@ class Human(Agent):
         )
         target_row, target_col = (-1, -1)
         while (target_row, target_col) not in reachable_squares:
-            board.pyxel_manager.highlight_map_tiles(reachable_squares, client_id)
+            board.pyxel_manager.highlight_map_tiles(
+                reachable_squares, client_id, color=10
+            )
             target_row, target_col = board.pyxel_manager.get_user_input(
                 prompt="Select a valid board square to attack",
                 is_mouse=True,

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -79,6 +79,13 @@ class Agent(abc.ABC):
     ):
         pass
 
+    @staticmethod
+    @abc.abstractmethod
+    def select_board_square_target(
+        board, client_id, att_range, attacker
+    ) -> tuple[int, int]:
+        pass
+
 
 class Ai(Agent):
     @staticmethod
@@ -190,6 +197,21 @@ class Ai(Agent):
                     return attack_coords
 
         return attack_coords
+
+    @staticmethod
+    def select_board_square_target(
+        board, client_id, att_range, attacker
+    ) -> tuple[int, int]:
+        """
+        ai will only throw elements at enemeies, so they find an enemy to target
+        """
+        in_range_enemies = board.find_in_range_opponents_or_allies(
+            attacker, att_range, opponents=True
+        )
+        target = attacker.select_attack_target(in_range_enemies, board)
+        if target is None:
+            return None, None
+        return board.find_location_of_target(target)
 
 
 class Human(Agent):
@@ -342,3 +364,21 @@ class Human(Agent):
         return board.pyxel_manager.pick_rotated_attack_coordinates(
             shape, starting_coord, client_id
         )
+
+    @staticmethod
+    def select_board_square_target(
+        board, client_id, att_range, attacker
+    ) -> tuple[int, int]:
+        attacker_loc = board.find_location_of_target(attacker)
+        reachable_squares, _ = board.find_all_reachable_paths(
+            start=attacker_loc, num_moves=att_range, exclude_walls_only=True
+        )
+        target_row, target_col = (-1, -1)
+        while (target_row, target_col) not in reachable_squares:
+            board.pyxel_manager.highlight_map_tiles(reachable_squares, client_id)
+            target_row, target_col = board.pyxel_manager.get_user_input(
+                prompt="Select a valid board square to attack",
+                is_mouse=True,
+                client_id=client_id,
+            )
+        return target_row, target_col

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -374,8 +374,10 @@ class Human(Agent):
             start=attacker_loc, num_moves=att_range, exclude_walls_only=True
         )
         target_row, target_col = (-1, -1)
+        board.pyxel_manager.draw_cursor_grid_shape(
+            shape, attacker.client_id, reachable_squares
+        )
         while (target_row, target_col) not in reachable_squares:
-            board.pyxel_manager.draw_cursor_grid_shape(shape, attacker.client_id)
             target_row, target_col = board.pyxel_manager.get_user_input(
                 prompt="Select a valid board square to attack",
                 is_mouse=True,

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -373,6 +373,7 @@ class Human(Agent):
         reachable_squares, _ = board.find_all_reachable_paths(
             start=attacker_loc, num_moves=att_range, exclude_walls_only=True
         )
+        reachable_squares.append(attacker_loc)
         target_row, target_col = (-1, -1)
         board.pyxel_manager.draw_cursor_grid_shape(
             shape, attacker.client_id, reachable_squares

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -82,7 +82,7 @@ class Agent(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def select_board_square_target(
-        board, client_id, att_range, attacker
+        board, client_id, att_range, attacker, shape
     ) -> tuple[int, int]:
         pass
 
@@ -200,7 +200,7 @@ class Ai(Agent):
 
     @staticmethod
     def select_board_square_target(
-        board, client_id, att_range, attacker
+        board, client_id, att_range, attacker, shape
     ) -> tuple[int, int]:
         """
         ai will only throw elements at enemeies, so they find an enemy to target
@@ -367,7 +367,7 @@ class Human(Agent):
 
     @staticmethod
     def select_board_square_target(
-        board, client_id, att_range, attacker
+        board, client_id, att_range, attacker, shape
     ) -> tuple[int, int]:
         attacker_loc = board.find_location_of_target(attacker)
         reachable_squares, _ = board.find_all_reachable_paths(
@@ -375,12 +375,11 @@ class Human(Agent):
         )
         target_row, target_col = (-1, -1)
         while (target_row, target_col) not in reachable_squares:
-            board.pyxel_manager.highlight_map_tiles(
-                reachable_squares, client_id, color=10
-            )
+            board.pyxel_manager.draw_cursor_grid_shape(shape, attacker.client_id)
             target_row, target_col = board.pyxel_manager.get_user_input(
                 prompt="Select a valid board square to attack",
                 is_mouse=True,
                 client_id=client_id,
             )
+        board.pyxel_manager.turn_off_cursor_grid_shape(attacker.client_id)
         return target_row, target_col

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -154,6 +154,9 @@ class Board:
         col: int,
         shape: set,
     ) -> None:
+        """
+        if you want this to also do damage, you must pass damage and an attacker
+        """
         for coordinate in shape:
             effect_row = row + coordinate[0]
             effect_col = col + coordinate[1]
@@ -320,8 +323,10 @@ class Board:
                     )
                     not in visited
                     and (
-                        # either you're only excluding walls and it's not a wall, or it's a legal move
+                        # either you're only excluding walls and it's in bounds and not a wall, or it's a legal move
                         exclude_walls_only
+                        and new_row < self.size
+                        and new_col < self.size
                         and not isinstance(
                             self.locations[new_row][new_col], obstacle.Wall
                         )
@@ -540,7 +545,7 @@ class Board:
         row, col = self.find_location_of_target(target)
         self.update_locations(row, col, None)
         self.pyxel_manager.remove_entity(target.id)
-        died_by = f" stepped on {damage_str} and" if damage_str else ""
+        died_by = f" stepped on{damage_str} and" if damage_str else ""
         self.pyxel_manager.log.append(f"{target.name}{died_by} has been killed.")
         # if it's your turn, end it immediately
         if target == self.acting_character:

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -277,6 +277,7 @@ class Board:
         self,
         start: tuple[int, int],
         num_moves: int,
+        exclude_walls_only: bool = False,
     ) -> tuple[list[tuple[int, int]], dict[tuple[int, int], list[tuple[int, int]]]]:
         """
         Finds all positions reachable within the movement range and the shortest path to each position.
@@ -284,6 +285,8 @@ class Board:
         Args:
             start: Starting position as (row, col)
             num_moves: Maximum number of moves allowed
+            exclude_walls_only: Only considers walls as an invalid position - useful when using this
+                to find potential attack square targets for area attacks
 
         Returns:
             A tuple containing:
@@ -316,7 +319,14 @@ class Board:
                         new_col := current_pos[1] + d_col,
                     )
                     not in visited
-                    and self.is_legal_move(new_row, new_col)
+                    and (
+                        # either you're only excluding walls and it's not a wall, or it's a legal move
+                        exclude_walls_only
+                        and not isinstance(
+                            self.locations[new_row][new_col], obstacle.Wall
+                        )
+                        or self.is_legal_move(new_row, new_col)
+                    )
                 ]
                 visited.update(valid_surrounding_positions)
                 queue.extend((pos, distance + 1) for pos in valid_surrounding_positions)

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -150,16 +150,12 @@ class Board:
     def add_effect_to_terrain_for_attack(
         self,
         effect_type: Type[obstacle.TerrainObject],
-        row: int,
-        col: int,
-        shape: set,
+        attack_coords: list[tuple[int, int]],
     ) -> None:
         """
         if you want this to also do damage, you must pass damage and an attacker
         """
-        for coordinate in shape:
-            effect_row = row + coordinate[0]
-            effect_col = col + coordinate[1]
+        for effect_row, effect_col in attack_coords:
             # check if row and col are in bounds
             if 0 <= effect_row < len(self.terrain):
                 if 0 <= effect_col < len(self.terrain[effect_row]):

--- a/Gloomhaven/backend/models/campaign_manager.py
+++ b/Gloomhaven/backend/models/campaign_manager.py
@@ -105,13 +105,13 @@ class Campaign:
 
     def run_levels(self):
         for i, _ in enumerate(self.levels):
-            output = self.run_level(self.levels.pop(0))
+            output, message = self.run_level(self.levels.pop(0))
 
             # if you don't win the level or if all levels are done, end here
             if output != GameState.WIN or not self.levels:
                 self.pyxel_manager.pause_for_all_players(
                     num_players=self.num_players,
-                    prompt="Game over, press esc to exit",
+                    prompt=message + "\nPress esc to enter",
                 )
                 # !!! should clean up gracefully here
                 return
@@ -119,7 +119,7 @@ class Campaign:
             # offer to save and continue to next level
             self.pyxel_manager.pause_for_all_players(
                 num_players=self.num_players,
-                prompt="All players must press enter to continue",
+                prompt=message + "\nAll players must press enter to continue",
             )
             self.save_campaign()
 

--- a/Gloomhaven/backend/models/character.py
+++ b/Gloomhaven/backend/models/character.py
@@ -53,6 +53,11 @@ class Character(abc.ABC):
         )
         return action_card_to_perform
 
+    def select_board_square_target(self, board, att_range):
+        return self.agent.select_board_square_target(
+            board, self.client_id, att_range, self
+        )
+
     def decide_if_move_first(self, action_card):
         return self.agent.decide_if_move_first(self.pyxel_manager, self.client_id)
 

--- a/Gloomhaven/backend/models/character.py
+++ b/Gloomhaven/backend/models/character.py
@@ -53,9 +53,9 @@ class Character(abc.ABC):
         )
         return action_card_to_perform
 
-    def select_board_square_target(self, board, att_range):
+    def select_board_square_target(self, board, att_range, shape):
         return self.agent.select_board_square_target(
-            board, self.client_id, att_range, self
+            board, self.client_id, att_range, self, shape
         )
 
     def decide_if_move_first(self, action_card):

--- a/Gloomhaven/backend/models/character.py
+++ b/Gloomhaven/backend/models/character.py
@@ -112,6 +112,7 @@ class Character(abc.ABC):
         """
         # we do not rotate cirlces or rings
         if shapes.is_circle_or_ring(shape):
+            print("it's a circle!")
             return [
                 (starting_coord[0] + coordinate[0], starting_coord[1] + coordinate[1])
                 for coordinate in shape

--- a/Gloomhaven/backend/models/character_classes/bloodooze.py
+++ b/Gloomhaven/backend/models/character_classes/bloodooze.py
@@ -6,7 +6,7 @@ cards = [
     actions.ActionCard(
         attack_name="Finishing Blow",
         actions=[
-            actions.AreaAttack(shape=shapes.arc(3), strength=1),
+            actions.AreaAttackFromSelf(shape=shapes.arc(3), strength=1),
         ],
         movement=3,
         jump=False,
@@ -30,7 +30,7 @@ cards = [
         attack_name="Engulf",
         actions=[
             actions.Pull(2, 2),
-            actions.AreaAttack(shape=shapes.circle(1), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=3),
         ],
         movement=2,
         jump=False,
@@ -38,7 +38,7 @@ cards = [
     actions.ActionCard(
         attack_name="Blood Rain",
         actions=[
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 shape=shapes.ring(2), element_type=obstacle.Fire
             ),
             actions.WeakenAllEnemies(2, 2),

--- a/Gloomhaven/backend/models/character_classes/corpse.py
+++ b/Gloomhaven/backend/models/character_classes/corpse.py
@@ -6,7 +6,7 @@ cards = [
     actions.ActionCard(
         attack_name="Putrid Burst",
         actions=[
-            actions.AreaAttack(shape=shapes.cone(2), strength=1),
+            actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=1),
             actions.WeakenAllEnemies(2, 2),
         ],
         movement=2,
@@ -15,8 +15,8 @@ cards = [
     actions.ActionCard(
         attack_name="Infectious Trail",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.line(3), element_type=obstacle.Spores
+            actions.AreaAttackFromSelf(
+                shape=shapes.line(3), element_type=obstacle.Spores, strength=2
             ),
             actions.WeakenAllEnemies(1, 2),
         ],
@@ -32,7 +32,7 @@ cards = [
     actions.ActionCard(
         attack_name="Flesh Purge",
         actions=[
-            actions.AreaAttack(shape=shapes.cone(2), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=2),
             actions.CurseAllEnemies(2),
         ],
         movement=2,
@@ -42,7 +42,7 @@ cards = [
         attack_name="Corpse Explosion",
         actions=[
             actions.ModifySelfHealth(-2),
-            actions.AreaAttack(shape=shapes.circle(2), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=3),
         ],
         movement=1,
         jump=False,

--- a/Gloomhaven/backend/models/character_classes/demon.py
+++ b/Gloomhaven/backend/models/character_classes/demon.py
@@ -12,8 +12,8 @@ cards = [
     actions.ActionCard(
         attack_name="Void Circle",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Shadow, strength=2
             ),
             actions.WeakenAllEnemies(2, 2),
         ],
@@ -30,7 +30,7 @@ cards = [
         attack_name="Shadow Aegis",
         actions=[
             actions.ShieldAllAllies(3, 2, 3),
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 shape=shapes.ring(2), element_type=obstacle.Shadow
             ),
         ],
@@ -47,8 +47,8 @@ cards = [
         attack_name="Dark Blessing",
         actions=[
             actions.ChargeNextAttack(3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.bar(1, 2), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.bar(1, 2), element_type=obstacle.Shadow, strength=1
             ),
         ],
         movement=1,

--- a/Gloomhaven/backend/models/character_classes/elementalist.py
+++ b/Gloomhaven/backend/models/character_classes/elementalist.py
@@ -6,7 +6,7 @@ cards = [
     actions.ActionCard(
         attack_name="Shockwave",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(1), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=3),
             actions.PushAllEnemies(1, 3),
         ],
         movement=1,
@@ -15,9 +15,8 @@ cards = [
     actions.ActionCard(
         attack_name="Ring of Fire",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(2), strength=2),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Fire
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Fire, strength=2
             ),
         ],
         movement=1,
@@ -26,7 +25,7 @@ cards = [
     actions.ActionCard(
         attack_name="Explosive Blast",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(2), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=2),
             actions.WeakenEnemy(2, 2),
             actions.PushAllEnemies(2, 2),
         ],
@@ -36,8 +35,8 @@ cards = [
     actions.ActionCard(
         attack_name="Storm of Blades",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(1), strength=3),
-            actions.AreaAttack(shape=shapes.circle(2), strength=1),
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=1),
         ],
         movement=2,
         jump=False,
@@ -45,7 +44,7 @@ cards = [
     actions.ActionCard(
         attack_name="Earthquake",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(2), strength=4),
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=4),
             actions.MakeObstableArea(obstacle_type=obstacle.Rock, shape=shapes.arc(3)),
         ],
         movement=1,
@@ -54,9 +53,8 @@ cards = [
     actions.ActionCard(
         attack_name="Flame Wall",
         actions=[
-            actions.AreaAttack(shape=shapes.line(3), strength=3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.line(3), element_type=obstacle.Fire
+            actions.AreaAttackFromSelf(
+                shape=shapes.line(3), element_type=obstacle.Fire, strength=3
             ),
         ],
         movement=1,
@@ -65,7 +63,7 @@ cards = [
     actions.ActionCard(
         attack_name="Thunder Burst",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(2), strength=4),
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=4),
             actions.PushAllEnemies(1, 2),
         ],
         movement=1,

--- a/Gloomhaven/backend/models/character_classes/fairy.py
+++ b/Gloomhaven/backend/models/character_classes/fairy.py
@@ -6,8 +6,8 @@ cards = [
     actions.ActionCard(
         attack_name="Shadow Veil",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Shadow, strength=1
             ),
             actions.WeakenAllEnemies(2, 2),
         ],
@@ -29,10 +29,9 @@ cards = [
     actions.ActionCard(
         attack_name="Fairy Ring",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.ring(2), element_type=obstacle.Spores
-            ),
-            actions.SingleTargetAttack(4, 2),
+            actions.AreaAttackFromSelf(
+                shape=shapes.ring(2), element_type=obstacle.Spores, strength=3
+            )
         ],
         movement=3,
         jump=True,
@@ -41,8 +40,8 @@ cards = [
         attack_name="Shadow Dance",
         actions=[
             actions.Teleport(4),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(1), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(1), element_type=obstacle.Shadow, strength=2
             ),
         ],
         movement=2,

--- a/Gloomhaven/backend/models/character_classes/firesprite.py
+++ b/Gloomhaven/backend/models/character_classes/firesprite.py
@@ -15,8 +15,8 @@ cards = [
     actions.ActionCard(
         attack_name="Fire Trail",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.line(4), element_type=obstacle.Fire
+            actions.AreaAttackFromSelf(
+                shape=shapes.line(4), element_type=obstacle.Fire, strength=1
             ),
             actions.WeakenAllEnemies(1, 2),
         ],
@@ -26,7 +26,7 @@ cards = [
     actions.ActionCard(
         attack_name="Spark Storm",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(1), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=2),
         ],
         movement=3,
         jump=True,
@@ -34,10 +34,9 @@ cards = [
     actions.ActionCard(
         attack_name="Burning Dash",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.cone(2), element_type=obstacle.Fire
+            actions.AreaAttackFromSelf(
+                shape=shapes.cone(2), element_type=obstacle.Fire, strength=2
             ),
-            actions.AreaAttack(shape=shapes.cone(2), strength=2),
         ],
         movement=5,  # Increased base movement to represent the "dash"
         jump=True,
@@ -46,8 +45,8 @@ cards = [
         attack_name="Ember Shield",
         actions=[
             actions.ShieldAllAllies(1, 2, 2),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.ring(2), element_type=obstacle.Fire
+            actions.AreaAttackFromSelf(
+                shape=shapes.ring(2), element_type=obstacle.Fire, strength=1
             ),
         ],
         movement=3,
@@ -57,7 +56,7 @@ cards = [
         attack_name="Heat Wave",
         actions=[
             actions.WeakenAllEnemies(2, 2),
-            actions.AreaAttack(shapes.cone(2), 2),
+            actions.AreaAttackFromSelf(shapes.cone(2), 2),
         ],
         movement=3,
         jump=True,

--- a/Gloomhaven/backend/models/character_classes/fleshgolem.py
+++ b/Gloomhaven/backend/models/character_classes/fleshgolem.py
@@ -17,7 +17,7 @@ cards = [
     actions.ActionCard(
         attack_name="Thunderous Charge",
         actions=[
-            actions.AreaAttack(shape=shapes.line(3), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.line(3), strength=3),
             actions.Push(2, 3),
         ],
         movement=4,
@@ -39,7 +39,7 @@ cards = [
         attack_name="Stone Flesh",
         actions=[
             actions.ShieldSelf(2, 2),
-            actions.AreaAttack(shape=shapes.bar(1, 2), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.bar(1, 2), strength=3),
         ],
         movement=3,
         jump=False,

--- a/Gloomhaven/backend/models/character_classes/ghost.py
+++ b/Gloomhaven/backend/models/character_classes/ghost.py
@@ -21,10 +21,9 @@ cards = [
     actions.ActionCard(
         attack_name="Haunting Mist",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.arc(4), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.arc(4), element_type=obstacle.Shadow, strength=3
             ),
-            actions.AreaAttack(shape=shapes.arc(4), strength=3),
             actions.WeakenAllEnemies(1, 2),
         ],
         movement=3,
@@ -40,10 +39,9 @@ cards = [
         attack_name="Ethereal Dance",
         actions=[
             actions.Teleport(3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Shadow, strength=3
             ),
-            actions.AreaAttack(shape=shapes.circle(2), strength=3),
         ],
         movement=2,
         jump=True,
@@ -52,7 +50,7 @@ cards = [
         attack_name="Terror",
         actions=[
             actions.CurseAllEnemies(2),
-            actions.AreaAttack(shapes.circle(2), 1),
+            actions.AreaAttackFromSelf(shapes.circle(2), 1),
             actions.PushAllEnemies(2, 2),
         ],
         movement=2,

--- a/Gloomhaven/backend/models/character_classes/ice_dragon.py
+++ b/Gloomhaven/backend/models/character_classes/ice_dragon.py
@@ -7,9 +7,8 @@ cards = [
     actions.ActionCard(
         attack_name="Frost Breath",
         actions=[
-            actions.AreaAttack(shape=shapes.cone(3), strength=2),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.cone(3), element_type=obstacle.Ice
+            actions.AreaAttackFromSelf(
+                shape=shapes.cone(3), element_type=obstacle.Ice, strength=3
             ),
         ],
         movement=2,
@@ -27,7 +26,7 @@ cards = [
     actions.ActionCard(
         attack_name="Ice Wall",
         actions=[
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 element_type=obstacle.Ice, shape=shapes.bar(1, 3)
             ),
             actions.ShieldSelf(2, 2),
@@ -38,7 +37,7 @@ cards = [
     actions.ActionCard(
         attack_name="Wing Buffet",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(1), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=2),
             actions.PushAllEnemies(1, 1),
         ],
         movement=4,
@@ -48,8 +47,8 @@ cards = [
         attack_name="Freezing Roar",
         actions=[
             actions.WeakenAllEnemies(2, 3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.ring(2), element_type=obstacle.Ice
+            actions.AreaAttackFromSelf(
+                shape=shapes.ring(2), element_type=obstacle.Ice, strength=2
             ),
         ],
         movement=2,

--- a/Gloomhaven/backend/models/character_classes/ice_monster.py
+++ b/Gloomhaven/backend/models/character_classes/ice_monster.py
@@ -6,9 +6,8 @@ cards = [
     actions.ActionCard(
         attack_name="Ice Slam",
         actions=[
-            actions.SingleTargetAttack(4, 1),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(1), element_type=obstacle.Ice
+            actions.AreaAttackFromSelf(
+                shape=shapes.ring(1), element_type=obstacle.Ice, strength=3
             ),
         ],
         movement=2,
@@ -26,7 +25,7 @@ cards = [
     actions.ActionCard(
         attack_name="Avalanche Charge",
         actions=[
-            actions.AreaAttack(shape=shapes.line(3), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.line(3), strength=3),
             actions.PushAllEnemies(1, 1),
         ],
         movement=4,
@@ -36,8 +35,8 @@ cards = [
         attack_name="Fortify",
         actions=[
             actions.ShieldSelf(3, 2),
-            actions.ElementAreaEffectFromSelf(
-                element_type=obstacle.Ice, shape=shapes.ring(2)
+            actions.AreaAttackFromSelf(
+                element_type=obstacle.Ice, shape=shapes.ring(2), strength=2
             ),
         ],
         movement=1,

--- a/Gloomhaven/backend/models/character_classes/malformed.py
+++ b/Gloomhaven/backend/models/character_classes/malformed.py
@@ -5,7 +5,7 @@ from backend.models import obstacle
 cards = [
     actions.ActionCard(
         attack_name="Mutation Surge",
-        actions=[actions.AreaAttack(shape=shapes.arc(3), strength=4)],
+        actions=[actions.AreaAttackFromSelf(shape=shapes.arc(3), strength=4)],
         movement=3,
         jump=False,
     ),
@@ -22,7 +22,7 @@ cards = [
     actions.ActionCard(
         attack_name="Writhing Mass",
         actions=[
-            actions.AreaAttack(shape=shapes.arc(3), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.arc(3), strength=2),
             actions.CurseAllEnemies(2),
         ],
         movement=3,
@@ -37,7 +37,7 @@ cards = [
     actions.ActionCard(
         attack_name="Flesh Eruption",
         actions=[
-            actions.AreaAttack(shape=shapes.cone(3), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.cone(3), strength=3),
             actions.WeakenAllEnemies(1, 2),
         ],
         movement=2,
@@ -47,7 +47,7 @@ cards = [
         attack_name="Consume Self",
         actions=[
             actions.ModifySelfHealth(-3),
-            actions.AreaAttack(shape=shapes.circle(1), strength=5),
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=5),
         ],
         movement=1,
         jump=False,

--- a/Gloomhaven/backend/models/character_classes/miner.py
+++ b/Gloomhaven/backend/models/character_classes/miner.py
@@ -15,7 +15,7 @@ cards = [
     ),
     action_model.ActionCard(
         attack_name="Pickaxe Swipe",
-        actions=[action_model.AreaAttackFromSelf(shape=shapes.arc(4), strength=3)],
+        actions=[action_model.AreaAttackFromSelf(shape=shapes.arc(2), strength=4)],
         movement=3,
         jump=False,
     ),

--- a/Gloomhaven/backend/models/character_classes/miner.py
+++ b/Gloomhaven/backend/models/character_classes/miner.py
@@ -15,7 +15,7 @@ cards = [
     ),
     action_model.ActionCard(
         attack_name="Pickaxe Swipe",
-        actions=[action_model.AreaAttack(shape=shapes.arc(4), strength=3)],
+        actions=[action_model.AreaAttackFromSelf(shape=shapes.arc(4), strength=3)],
         movement=3,
         jump=False,
     ),
@@ -41,7 +41,7 @@ cards = [
         attack_name="Crystal Ward",
         actions=[
             action_model.ModifySelfHealth(strength=4),
-            action_model.AreaAttack(shapes.ring(2), 2),
+            action_model.AreaAttackFromSelf(shapes.ring(2), 2),
         ],
         movement=2,
         jump=False,
@@ -59,7 +59,7 @@ cards = [
     action_model.ActionCard(
         attack_name="Desperate Mining",
         actions=[
-            action_model.AreaAttack(shape=shapes.bar(1, 2), strength=3),
+            action_model.AreaAttackFromSelf(shape=shapes.bar(1, 2), strength=3),
             action_model.BlessSelf(),
             action_model.ChargeNextAttack(strength=4),
             action_model.ModifySelfHealth(-3),

--- a/Gloomhaven/backend/models/character_classes/mobile_striker.py
+++ b/Gloomhaven/backend/models/character_classes/mobile_striker.py
@@ -4,20 +4,17 @@ import backend.utils.attack_shapes as shapes
 cards = [
     actions.ActionCard(
         attack_name="Forceful Strike",
-        actions=[
-            actions.SingleTargetAttack(4, 3),
-            actions.Push(2, 3)
-        ],
+        actions=[actions.SingleTargetAttack(4, 3), actions.Push(2, 3)],
         movement=4,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Sniper Shot",
         actions=[actions.SingleTargetAttack(5, 3)],
         movement=2,
-        jump=True
+        jump=True,
     ),
-    actions.ActionCard( 
+    actions.ActionCard(
         attack_name="Throwing Knives",
         actions=[
             actions.SingleTargetAttack(2, 2),
@@ -25,36 +22,29 @@ cards = [
             actions.SingleTargetAttack(2, 2),
         ],
         movement=4,
-        jump=True
+        jump=True,
     ),
-    actions.ActionCard( 
+    actions.ActionCard(
         attack_name="Hook and Slice",
-        actions=[
-            actions.Pull(2, 3),
-            actions.SingleTargetAttack(4, 1)
-        ],
+        actions=[actions.Pull(2, 3), actions.SingleTargetAttack(4, 1)],
         movement=3,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Whirlwind Assault",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(1), strength=3),
-            actions.ChargeNextAttack(2)
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=3),
+            actions.ChargeNextAttack(2),
         ],
         movement=3,
-        jump=True
+        jump=True,
     ),
-    
     actions.ActionCard(
         attack_name="Vital Strike",
-        actions=[
-            actions.SingleTargetAttack(6, 1),
-            actions.CurseSelf() 
-        ],
+        actions=[actions.SingleTargetAttack(6, 1), actions.CurseSelf()],
         movement=2,
-        jump=True
-    )
+        jump=True,
+    ),
 ]
 
 health = 5

--- a/Gloomhaven/backend/models/character_classes/monk.py
+++ b/Gloomhaven/backend/models/character_classes/monk.py
@@ -45,7 +45,7 @@ cards = [
         actions=[
             action_model.BlessAndChargeAlly(2, 3),
             action_model.CurseSelf(),
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.line(5), damage=3, att_range=2
             ),
         ],
@@ -54,7 +54,7 @@ cards = [
     ),
     action_model.ActionCard(
         attack_name="Scythe Swipe",
-        actions=[action_model.AreaAttack(shapes.arc(3), 4)],
+        actions=[action_model.AreaAttackFromSelf(shapes.arc(3), 4)],
         movement=2,
         jump=False,
     ),

--- a/Gloomhaven/backend/models/character_classes/monk.py
+++ b/Gloomhaven/backend/models/character_classes/monk.py
@@ -45,7 +45,9 @@ cards = [
         actions=[
             action_model.BlessAndChargeAlly(2, 3),
             action_model.CurseSelf(),
-            action_model.AreaAttack(shapes.line(5), 4),
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.line(5), damage=3, att_range=2
+            ),
         ],
         movement=2,
         jump=False,

--- a/Gloomhaven/backend/models/character_classes/necromancer.py
+++ b/Gloomhaven/backend/models/character_classes/necromancer.py
@@ -6,7 +6,7 @@ cards = [
     action_model.ActionCard(
         attack_name="Fear Mongerer",
         actions=[
-            action_model.AreaAttack(shapes.circle(2), 2),
+            action_model.AreaAttackFromSelf(shapes.circle(2), 2),
             action_model.PushAllEnemies(3, 2),
         ],
         movement=0,
@@ -24,7 +24,7 @@ cards = [
     action_model.ActionCard(
         attack_name="Life Drain",
         actions=[
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.circle(radius=1), damage=4, att_range=2
             ),
             action_model.ModifySelfHealth(4),
@@ -51,7 +51,7 @@ cards = [
         attack_name="Death's Embrace",
         actions=[
             action_model.CurseAllEnemies(3),
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.ring(1), damage=4, element_type=Shadow, att_range=2
             ),
             action_model.PushAllEnemies(1, 3),
@@ -69,13 +69,13 @@ cards = [
         # switch this to shadow that shows up around you
         attack_name="Shadow Tendril",
         actions=[
-            action_model.ElementAreaEffectFromSelf(
+            action_model.AreaAttackFromSelf(
                 shape=shapes.circle(
                     2,
                 ),
                 element_type=Shadow,
             ),
-            action_model.AreaAttack(shapes.arc(4), 2),
+            action_model.AreaAttackFromSelf(shapes.arc(4), 2),
         ],
         movement=3,
         jump=False,

--- a/Gloomhaven/backend/models/character_classes/necromancer.py
+++ b/Gloomhaven/backend/models/character_classes/necromancer.py
@@ -25,7 +25,7 @@ cards = [
         attack_name="Life Drain",
         actions=[
             action_model.ElementAreaEffectWithTarget(
-                shape=shapes.circle(radius=3), damage=3, att_range=2
+                shape=shapes.circle(radius=1), damage=4, att_range=2
             ),
             action_model.ModifySelfHealth(4),
         ],
@@ -51,7 +51,9 @@ cards = [
         attack_name="Death's Embrace",
         actions=[
             action_model.CurseAllEnemies(3),
-            action_model.AreaAttack(shapes.ring(1), 4),
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.ring(1), damage=4, element_type=Shadow, att_range=2
+            ),
             action_model.PushAllEnemies(1, 3),
         ],
         movement=0,

--- a/Gloomhaven/backend/models/character_classes/necromancer.py
+++ b/Gloomhaven/backend/models/character_classes/necromancer.py
@@ -24,7 +24,9 @@ cards = [
     action_model.ActionCard(
         attack_name="Life Drain",
         actions=[
-            action_model.AreaAttack(shapes.circle(radius=3), 2),
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.circle(radius=3), damage=3, att_range=2
+            ),
             action_model.ModifySelfHealth(4),
         ],
         movement=2,

--- a/Gloomhaven/backend/models/character_classes/orchestrator.py
+++ b/Gloomhaven/backend/models/character_classes/orchestrator.py
@@ -13,8 +13,8 @@ cards = [
     actions.ActionCard(
         attack_name="Reality Warp",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.cone(3), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.cone(3), element_type=obstacle.Shadow, strength=3
             ),
             actions.Teleport(3),
             actions.Teleport(3),
@@ -26,7 +26,7 @@ cards = [
     actions.ActionCard(
         attack_name="Nightmare Web",
         actions=[
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 element_type=obstacle.Trap, shape=shapes.ring(2)
             ),
             actions.Pull(2, 3),
@@ -39,8 +39,8 @@ cards = [
     actions.ActionCard(
         attack_name="Dance of Darkness",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Shadow, strength=2
             ),
             actions.WeakenAllEnemies(2, 2),
             actions.HealAllAllies(3, 3),

--- a/Gloomhaven/backend/models/character_classes/puppet.py
+++ b/Gloomhaven/backend/models/character_classes/puppet.py
@@ -7,23 +7,20 @@ cards = [
         attack_name="Critical Meltdown",
         actions=[
             actions.ModifySelfHealth(-5),
-            actions.AreaAttack(
-                shape=shapes.circle(2),
-                strength=6
-            )
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=6),
         ],
         movement=3,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Chain Reaction",
         actions=[
             actions.ModifySelfHealth(-2),
-            actions.SingleTargetAttack(3,2),
-            actions.SingleTargetAttack(3,2),
+            actions.SingleTargetAttack(3, 2),
+            actions.SingleTargetAttack(3, 2),
         ],
         movement=4,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Power Surge",
@@ -31,38 +28,30 @@ cards = [
             actions.ChargeNextAttack(4),
         ],
         movement=0,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Containment Breach",
         actions=[
             actions.Pull(3, 3),
             actions.ModifySelfHealth(-4),
-            actions.AreaAttack(
-                shape=shapes.circle(1),
-                strength=5
-            )
+            actions.AreaAttackFromSelf(shape=shapes.circle(1), strength=5),
         ],
         movement=2,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Destabilize",
-        actions=[
-            actions.ShieldSelf(4, 1),
-            actions.WeakenAllEnemies(3, 2)
-        ],
+        actions=[actions.ShieldSelf(4, 1), actions.WeakenAllEnemies(3, 2)],
         movement=2,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Execute Command",
-        actions=[
-            actions.SingleTargetAttack(3, 2)
-        ],
+        actions=[actions.SingleTargetAttack(3, 2)],
         movement=2,
-        jump=False
-    )
+        jump=False,
+    ),
 ]
 
 health = 4

--- a/Gloomhaven/backend/models/character_classes/skeleton.py
+++ b/Gloomhaven/backend/models/character_classes/skeleton.py
@@ -24,7 +24,7 @@ cards = [
     actions.ActionCard(
         attack_name="Sword Dance",
         actions=[
-            actions.AreaAttack(shape=shapes.arc(3), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.arc(3), strength=2),
             actions.ChargeNextAttack(2),
         ],
         movement=3,

--- a/Gloomhaven/backend/models/character_classes/snow_stalker.py
+++ b/Gloomhaven/backend/models/character_classes/snow_stalker.py
@@ -7,7 +7,7 @@ cards = [
         attack_name="Protective Snares",
         actions=[
             actions.ShieldAllAllies(2, 2, 3),
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 element_type=obstacle.Trap, shape=shapes.bar(1, 1)
             ),
         ],
@@ -17,7 +17,7 @@ cards = [
     actions.ActionCard(
         attack_name="Warming Fire",
         actions=[
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 shape=shapes.circle(1), element_type=obstacle.Fire
             ),
             actions.HealAllAllies(2, 2),
@@ -28,7 +28,7 @@ cards = [
     actions.ActionCard(
         attack_name="Trap Network",
         actions=[
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 element_type=obstacle.Trap, shape=shapes.ring(2)
             ),
             actions.Pull(2, 3),
@@ -51,7 +51,9 @@ cards = [
     actions.ActionCard(
         attack_name="Shadow Attack",
         actions=[
-            actions.ElementAreaEffectFromSelf(shapes.circle(2), obstacle.Shadow),
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Shadow, strength=1
+            ),
             actions.Pull(2, 3),
             actions.SingleTargetAttack(3, 1),
         ],

--- a/Gloomhaven/backend/models/character_classes/support_fungal.py
+++ b/Gloomhaven/backend/models/character_classes/support_fungal.py
@@ -7,8 +7,8 @@ cards = [
         attack_name="Healing Spores",
         actions=[
             actions.HealAllAllies(3, 3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(1), element_type=obstacle.Spores
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(1), element_type=obstacle.Spores, strength=1
             ),
         ],
         movement=2,
@@ -32,10 +32,9 @@ cards = [
     actions.ActionCard(
         attack_name="Spore Cloud",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(1), element_type=obstacle.Spores
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(1), element_type=obstacle.Spores, strength=2
             ),
-            actions.AreaAttack(shapes.circle(1), strength=2),
             actions.WeakenAllEnemies(2, 2),
         ],
         movement=2,
@@ -51,7 +50,7 @@ cards = [
         attack_name="Protective Bloom",
         actions=[
             actions.HealAllAllies(3, 5),
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 shape=shapes.ring(2), element_type=obstacle.PoisonShroom
             ),
         ],

--- a/Gloomhaven/backend/models/character_classes/support_healer.py
+++ b/Gloomhaven/backend/models/character_classes/support_healer.py
@@ -5,63 +5,53 @@ from backend.models import obstacle
 healer_support_cards = [
     actions.ActionCard(
         attack_name="Healing Wave",
-        actions=[
-            actions.HealAllAllies(3, 3),
-            actions.BlessAllAllies(2)
-        ],
+        actions=[actions.HealAllAllies(3, 3), actions.BlessAllAllies(2)],
         movement=2,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Protective Barrier",
         actions=[
             actions.ShieldAllAllies(3, 2, 3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(1),
-                element_type=obstacle.Fire
-            )
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(1), element_type=obstacle.Fire, strength=2
+            ),
         ],
         movement=1,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Rejuvenating Touch",
-        actions=[
-            actions.HealAlly(5, 1),
-            actions.BlessAndChargeAlly(2, 1)
-        ],
+        actions=[actions.HealAlly(5, 1), actions.BlessAndChargeAlly(2, 1)],
         movement=3,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Mass Restoration",
         actions=[
             actions.HealAllAllies(2, 2),
             actions.ShieldAllAllies(2, 2, 2),
-            actions.ModifySelfHealth(-2)
+            actions.ModifySelfHealth(-2),
         ],
         movement=1,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Holy Nova",
-        actions=[
-            actions.SingleTargetAttack(2, 3),
-            actions.HealAllAllies(2, 3)
-        ],
+        actions=[actions.SingleTargetAttack(2, 3), actions.HealAllAllies(2, 3)],
         movement=2,
-        jump=False
+        jump=False,
     ),
     actions.ActionCard(
         attack_name="Divine Protection",
         actions=[
             actions.ShieldSelf(2, 2),
             actions.ShieldAllAllies(2, 1, 2),
-            actions.Teleport(3)
+            actions.Teleport(3),
         ],
         movement=0,
-        jump=False
-    )
+        jump=False,
+    ),
 ]
 
 health = 4

--- a/Gloomhaven/backend/models/character_classes/support_mage.py
+++ b/Gloomhaven/backend/models/character_classes/support_mage.py
@@ -36,7 +36,7 @@ magic_user_cards = [
         attack_name="Chain Lightning",
         actions=[
             actions.SingleTargetAttack(3, 4),
-            actions.AreaAttack(shape=shapes.line(5), strength=2),
+            actions.AreaAttackFromSelf(shape=shapes.line(5), strength=2),
         ],
         movement=1,
         jump=False,

--- a/Gloomhaven/backend/models/character_classes/tank_melee.py
+++ b/Gloomhaven/backend/models/character_classes/tank_melee.py
@@ -16,7 +16,7 @@ cards = [
     ),
     actions.ActionCard(
         attack_name="Sweeping Blow",
-        actions=[actions.AreaAttack(shape=shapes.cone(2), strength=2)],
+        actions=[actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=2)],
         movement=3,
         jump=False,
     ),

--- a/Gloomhaven/backend/models/character_classes/trap_specialist.py
+++ b/Gloomhaven/backend/models/character_classes/trap_specialist.py
@@ -7,9 +7,7 @@ trap_specialist_cards = [
         attack_name="Ice and Steel",
         actions=[
             actions.SingleTargetAttack(3, 3),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.line(3), element_type=obstacle.Ice
-            ),
+            actions.AreaAttackFromSelf(shape=shapes.line(3), element_type=obstacle.Ice),
         ],
         movement=2,
         jump=True,
@@ -17,9 +15,7 @@ trap_specialist_cards = [
     actions.ActionCard(
         attack_name="Trap Network",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.arc(5), element_type=obstacle.Trap
-            ),
+            actions.AreaAttackFromSelf(shape=shapes.arc(5), element_type=obstacle.Trap),
             actions.PushAllEnemies(2, 2),
         ],
         movement=2,
@@ -28,12 +24,9 @@ trap_specialist_cards = [
     actions.ActionCard(
         attack_name="Frozen Path",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.line(3), element_type=obstacle.Ice
-            ),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.line(3), element_type=obstacle.Ice
-            ),
+            actions.AreaAttackFromSelf(
+                shape=shapes.line(3), element_type=obstacle.Ice, strength=3
+            )
         ],
         movement=3,
         jump=True,
@@ -41,9 +34,8 @@ trap_specialist_cards = [
     actions.ActionCard(
         attack_name="Shadow Strike",
         actions=[
-            actions.SingleTargetAttack(4, 2),
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Shadow
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Shadow, strength=3
             ),
         ],
         movement=2,
@@ -52,7 +44,7 @@ trap_specialist_cards = [
     actions.ActionCard(
         attack_name="Deadly Surprise",
         actions=[
-            actions.ElementAreaEffectFromSelf(
+            actions.AreaAttackFromSelf(
                 shape=shapes.circle(1), element_type=obstacle.Trap
             ),
             actions.Pull(3, 2),
@@ -63,8 +55,8 @@ trap_specialist_cards = [
     actions.ActionCard(
         attack_name="Ice Prison",
         actions=[
-            actions.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2), element_type=obstacle.Ice
+            actions.AreaAttackFromSelf(
+                shape=shapes.circle(2), element_type=obstacle.Ice, strength=2
             ),
             actions.WeakenAllEnemies(1, 2),
         ],

--- a/Gloomhaven/backend/models/character_classes/wailing_spirit.py
+++ b/Gloomhaven/backend/models/character_classes/wailing_spirit.py
@@ -6,7 +6,7 @@ cards = [
     actions.ActionCard(
         attack_name="Cold Tears",
         actions=[
-            actions.ElementAreaEffectWithTarget(
+            actions.AreaAttackWithTarget(
                 shape=shapes.ring(1), element_type=obstacle.Ice, att_range=3, damage=3
             ),
             actions.CurseAllEnemies(3),
@@ -35,7 +35,7 @@ cards = [
     actions.ActionCard(
         attack_name="Blood Rain",
         actions=[
-            actions.AreaAttack(shape=shapes.circle(2), strength=3),
+            actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=3),
             actions.WeakenAllEnemies(1, 2),
         ],
         movement=2,

--- a/Gloomhaven/backend/models/character_classes/wailing_spirit.py
+++ b/Gloomhaven/backend/models/character_classes/wailing_spirit.py
@@ -7,63 +7,46 @@ cards = [
         attack_name="Cold Tears",
         actions=[
             actions.ElementAreaEffectWithTarget(
-                shape=shapes.ring(1),
-                element_type=obstacle.Ice,
-                att_range=3
+                shape=shapes.ring(1), element_type=obstacle.Ice, att_range=3, damage=3
             ),
-            actions.CurseAllEnemies(3)
+            actions.CurseAllEnemies(3),
         ],
         movement=3,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Haunting Screech",
-        actions=[
-            actions.WeakenAllEnemies(2, 3),
-            actions.PushAllEnemies(2, 3)
-        ],
+        actions=[actions.WeakenAllEnemies(2, 3), actions.PushAllEnemies(2, 3)],
         movement=3,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Bone Rally",
-        actions=[
-            actions.SingleTargetAttack(3, 2),
-            actions.SummonSkeleton()
-        ],
+        actions=[actions.SingleTargetAttack(3, 2), actions.SummonSkeleton()],
         movement=4,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Psychic Torment",
-        actions=[
-            actions.CurseAllEnemies(3),
-            actions.Pull(2, 3)
-        ],
+        actions=[actions.CurseAllEnemies(3), actions.Pull(2, 3)],
         movement=3,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Blood Rain",
         actions=[
-            actions.AreaAttack(
-                shape=shapes.circle(2),
-                strength=3
-            ),
-            actions.WeakenAllEnemies(1, 2)
+            actions.AreaAttack(shape=shapes.circle(2), strength=3),
+            actions.WeakenAllEnemies(1, 2),
         ],
         movement=2,
-        jump=True
+        jump=True,
     ),
     actions.ActionCard(
         attack_name="Maddening Presence",
-        actions=[
-            actions.Curse(3),
-            actions.WeakenEnemy(3, 3)
-        ],
+        actions=[actions.Curse(3), actions.WeakenEnemy(3, 3)],
         movement=3,
-        jump=True
-    )
+        jump=True,
+    ),
 ]
 
 health = 3

--- a/Gloomhaven/backend/models/character_classes/wizard.py
+++ b/Gloomhaven/backend/models/character_classes/wizard.py
@@ -6,7 +6,7 @@ cards = [
     action_model.ActionCard(
         attack_name="Fireball",
         actions=[
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.circle(1),
                 element_type=obstacle.Fire,
                 att_range=4,
@@ -19,10 +19,10 @@ cards = [
     action_model.ActionCard(
         attack_name="Fire and Ice",
         actions=[
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.cone(2), att_range=2, damage=2, element_type=obstacle.Fire
             ),
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.cone(2), att_range=2, damage=2, element_type=obstacle.Ice
             ),
         ],
@@ -44,10 +44,9 @@ cards = [
     action_model.ActionCard(
         attack_name="Masochistic Explosion",
         actions=[
-            action_model.ElementAreaEffectFromSelf(
-                element_type=obstacle.Fire, shape=shapes.circle(2)
+            action_model.AreaAttackFromSelf(
+                element_type=obstacle.Fire, shape=shapes.circle(2), strength=5
             ),
-            action_model.AreaAttack(shape=shapes.circle(2), strength=5),
             action_model.ModifySelfHealth(-3),
         ],
         movement=3,
@@ -56,7 +55,7 @@ cards = [
     action_model.ActionCard(
         attack_name="Lightning Charge",
         actions=[
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.line(3), damage=4, att_range=2
             ),
             action_model.ModifySelfHealth(3),
@@ -76,7 +75,7 @@ cards = [
     action_model.ActionCard(
         attack_name="Phase Strike",
         actions=[
-            action_model.ElementAreaEffectWithTarget(
+            action_model.AreaAttackWithTarget(
                 shape=shapes.bar(1, 2), damage=4, att_range=3
             )
         ],

--- a/Gloomhaven/backend/models/character_classes/wizard.py
+++ b/Gloomhaven/backend/models/character_classes/wizard.py
@@ -56,7 +56,9 @@ cards = [
     action_model.ActionCard(
         attack_name="Lightning Charge",
         actions=[
-            action_model.AreaAttack(shape=shapes.line(3), strength=4),
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.line(3), damage=4, att_range=2
+            ),
             action_model.ModifySelfHealth(3),
         ],
         movement=1,

--- a/Gloomhaven/backend/models/character_classes/wizard.py
+++ b/Gloomhaven/backend/models/character_classes/wizard.py
@@ -10,8 +10,8 @@ cards = [
                 shape=shapes.circle(1),
                 element_type=obstacle.Fire,
                 att_range=4,
-            ),
-            action_model.SingleTargetAttack(3, 4),
+                damage=3,
+            )
         ],
         movement=2,
         jump=True,

--- a/Gloomhaven/backend/models/character_classes/wizard.py
+++ b/Gloomhaven/backend/models/character_classes/wizard.py
@@ -19,13 +19,11 @@ cards = [
     action_model.ActionCard(
         attack_name="Fire and Ice",
         actions=[
-            action_model.AreaAttack(shape=shapes.cone(3), strength=2),
-            action_model.ElementAreaEffectFromSelf(
-                shape=shapes.cone(3), element_type=obstacle.Fire
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.cone(2), att_range=2, damage=2, element_type=obstacle.Fire
             ),
-            action_model.ElementAreaEffectFromSelf(
-                shape=shapes.circle(2),
-                element_type=obstacle.Ice,
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.cone(2), att_range=2, damage=2, element_type=obstacle.Ice
             ),
         ],
         movement=3,
@@ -74,8 +72,12 @@ cards = [
         jump=False,
     ),
     action_model.ActionCard(
-        attack_name="B-Line",
-        actions=[action_model.AreaAttack(shape=shapes.line(3), strength=4)],
+        attack_name="Phase Strike",
+        actions=[
+            action_model.ElementAreaEffectWithTarget(
+                shape=shapes.bar(1, 2), damage=4, att_range=3
+            )
+        ],
         movement=2,
         jump=True,
     ),

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -251,9 +251,7 @@ class GameLoop:
             raise ValueError(
                 f"trying to end game when status is {self.game_state.name}"
             )
-        if not self.all_ai_mode:
-            self.pyxel_manager.add_to_personal_log(message)
-        return self.game_state
+        return self.game_state, message
 
     def _end_turn(self) -> None:
         self.board.acting_character = None
@@ -325,7 +323,7 @@ class GameLoop:
         return message
 
     def _win_game(self) -> str:
-        message = """You defeated the monster!! Victory!
+        message = """You defeated the monsters!! Victory!
     \\o/   Victory!
      |
     / \\

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -17,34 +17,34 @@ class Level:
 
 
 campaign_levels = [
-    # Level(
-    #     floor_color_map=[(1, 3), (5, 11)],
-    #     wall_color_map=[(1, 4), (13, 15)],
-    #     monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
-    #     pre_level_text=textwrap.fill(
-    #         """A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
-    #         TEXT_WIDTH,
-    #     ),
-    #     starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 8), (5, 2)],
-    #     wall_color_map=[],  # (1,2), (13,14)
-    #     monster_classes=[character.Demon, character.Fiend, character.FireSprite],
-    #     pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
-    #     starting_elements=[obstacle.Fire, obstacle.Trap, obstacle.Shadow],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 6), (5, 7)],
-    #     wall_color_map=[(13, 12)],
-    #     monster_classes=[
-    #         character.IceDragon,
-    #         character.SnowStalker,
-    #         character.IceMonster,
-    #     ],
-    #     pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
-    #     starting_elements=[obstacle.Ice, obstacle.Trap],
-    # ),
+    Level(
+        floor_color_map=[(1, 3), (5, 11)],
+        wall_color_map=[(1, 4), (13, 15)],
+        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+        pre_level_text=textwrap.fill(
+            """A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
+            TEXT_WIDTH,
+        ),
+        starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
+    ),
+    Level(
+        floor_color_map=[(1, 8), (5, 2)],
+        wall_color_map=[],  # (1,2), (13,14)
+        monster_classes=[character.Demon, character.Fiend, character.FireSprite],
+        pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
+        starting_elements=[obstacle.Fire, obstacle.Trap, obstacle.Shadow],
+    ),
+    Level(
+        floor_color_map=[(1, 6), (5, 7)],
+        wall_color_map=[(13, 12)],
+        monster_classes=[
+            character.IceDragon,
+            character.SnowStalker,
+            character.IceMonster,
+        ],
+        pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
+        starting_elements=[obstacle.Ice, obstacle.Trap],
+    ),
     Level(
         floor_color_map=[],
         wall_color_map=[],

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -34,17 +34,17 @@ campaign_levels = [
     #     pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
     #     starting_elements=[obstacle.Fire, obstacle.Trap, obstacle.Shadow],
     # ),
-    Level(
-        floor_color_map=[(1, 6), (5, 7)],
-        wall_color_map=[(13, 12)],
-        monster_classes=[
-            character.IceDragon,
-            character.SnowStalker,
-            character.IceMonster,
-        ],
-        pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
-        starting_elements=[obstacle.Ice, obstacle.Trap],
-    ),
+    # Level(
+    #     floor_color_map=[(1, 6), (5, 7)],
+    #     wall_color_map=[(13, 12)],
+    #     monster_classes=[
+    #         character.IceDragon,
+    #         character.SnowStalker,
+    #         character.IceMonster,
+    #     ],
+    #     pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
+    #     starting_elements=[obstacle.Ice, obstacle.Trap],
+    # ),
     Level(
         floor_color_map=[],
         wall_color_map=[],

--- a/Gloomhaven/backend/models/obstacle.py
+++ b/Gloomhaven/backend/models/obstacle.py
@@ -1,6 +1,7 @@
 import random
 from ..utils import attack_shapes as shapes
 
+
 class TerrainObject:
     def __init__(self, round_num: int, obj_id: int):
         self.emoji = "Ⅹ"
@@ -9,9 +10,10 @@ class TerrainObject:
         self.duration = 2
         self.damage = 0
         self.id = obj_id
-        
+
     def perform(self, row, col, board, affected_character):
         return
+
 
 class Rock(TerrainObject):
     def __init__(self, round_num, obj_id):
@@ -19,12 +21,14 @@ class Rock(TerrainObject):
         self.emoji = "🪨"
         self.pyxel_sprite_name = "boulder"
 
+
 class Fire(TerrainObject):
     def __init__(self, round_num, obj_id):
         super().__init__(round_num, obj_id)
         self.emoji = "🔥"
         self.pyxel_sprite_name = "fire"
         self.damage = 1
+
 
 class Ice(TerrainObject):
     def __init__(self, round_num, obj_id):
@@ -39,27 +43,34 @@ class Ice(TerrainObject):
             else:
                 affected_character.lose_turn = True
 
+
 class Trap(TerrainObject):
     def __init__(self, round_num, obj_id):
         super().__init__(round_num, obj_id)
         self.emoji = "🗯️ "
         self.damage = 3
-        self.pyxel_sprite_name="trap"
+        self.pyxel_sprite_name = "trap"
         self.duration = 1000
-    
+
     def perform(self, row, col, board, affected_character):
-        board.clear_terrain_square(row,col)
+        board.clear_terrain_square(row, col)
+
 
 class PoisonShroom(TerrainObject):
     def __init__(self, round_num, obj_id):
         super().__init__(round_num, obj_id)
         self.emoji = "🍄"
         self.pyxel_sprite_name = "poisonshroom"
-        
+
     def perform(self, row, col, board, affected_character):
         board.clear_terrain_square(row, col)
         board.pyxel_manager.log.append("The mushroom exploded into spores!")
-        board.add_effect_to_terrain_for_attack(Spores, row, col, shapes.circle(1))
+        spore_coords = [
+            (row + coordinate[0], col + coordinate[1])
+            for coordinate in shapes.circle(1)
+        ]
+        board.add_effect_to_terrain_for_attack(Spores, spore_coords)
+
 
 class Spores(TerrainObject):
     def __init__(self, round_num, obj_id):
@@ -68,6 +79,7 @@ class Spores(TerrainObject):
         self.pyxel_sprite_name = "spores"
         self.damage = 1
 
+
 class Wall(TerrainObject):
     def __init__(self, round_num, obj_id):
         super().__init__(round_num, obj_id)
@@ -75,11 +87,13 @@ class Wall(TerrainObject):
         self.pyxel_sprite_name = "boulder"
         self.duration = 1000
 
+
 class Shadow(TerrainObject):
     def __init__(self, round_num, obj_id):
         super().__init__(round_num, obj_id)
         self.emoji = "⚫️"
         self.pyxel_sprite_name = "shadow"
+
 
 class SlipAndLoseTurn(Exception):
     pass

--- a/Gloomhaven/backend/models/pyxel_backend.py
+++ b/Gloomhaven/backend/models/pyxel_backend.py
@@ -342,11 +342,21 @@ class PyxelManager:
                 return attack_coords
             current_shape = next(shape_iterator)
 
-    def draw_cursor_grid_shape(self, shape: list[tuple[int, int]], client_id: str):
+    def draw_cursor_grid_shape(
+        self,
+        shape: list[tuple[int, int]],
+        client_id: str,
+        valid_starting_squares: list[tuple[int, int]],
+    ):
         # flip to frontend tuple format
         tile_shape_offsets = [(col, row) for row, col in shape]
+        valid_pyxel_starting_squares = [
+            self.normalize_coordinate((col, row)) for row, col in valid_starting_squares
+        ]
         task = tasks.DrawCursorGridShape(
-            tile_shape_offsets=tile_shape_offsets, grid_color=10
+            tile_shape_offsets=tile_shape_offsets,
+            grid_color=10,
+            valid_starting_squares=valid_pyxel_starting_squares,
         )
         self.jsonify_and_send_task(task, client_id)
 

--- a/Gloomhaven/backend/models/pyxel_backend.py
+++ b/Gloomhaven/backend/models/pyxel_backend.py
@@ -341,3 +341,14 @@ class PyxelManager:
             if user_input == "f":
                 return attack_coords
             current_shape = next(shape_iterator)
+
+    def draw_cursor_grid_shape(self, shape: list[tuple[int, int]], client_id: str):
+        # flip to frontend tuple format
+        tile_shape_offsets = [(col, row) for row, col in shape]
+        task = tasks.DrawCursorGridShape(
+            tile_shape_offsets=tile_shape_offsets, grid_color=10
+        )
+        self.jsonify_and_send_task(task, client_id)
+
+    def turn_off_cursor_grid_shape(self, client_id: str):
+        self.jsonify_and_send_task(tasks.TurnOffCursorGridShape(), client_id)

--- a/Gloomhaven/backend/utils/attack_shapes.py
+++ b/Gloomhaven/backend/utils/attack_shapes.py
@@ -69,6 +69,8 @@ def ring(radius):
 
 
 def is_circle_or_ring(shape):
+    # sometimes we remove (0,0), so add just in case
+    shape.add((0, 0))
     max_coord = max(max(abs(x), abs(y)) for x, y in shape)
     circle_points = circle(max_coord)
     ring_points = ring(max_coord)

--- a/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
@@ -14,6 +14,10 @@ class UserInputManager:
         self.server_client = server_client
         self.mouse_tile_pos = None
         self.last_mouse_pos = (-1, -1)
+        self.draw_shape_with_cursor = False
+        self.cursor_shape_offsets = []
+        self.default_grid_color = 3
+        self.grid_color = self.default_grid_color
 
     def update(self):
         if pyxel.btnp(pyxel.KEY_ESCAPE):
@@ -44,6 +48,13 @@ class UserInputManager:
                     grid_left_px, grid_top_px, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX
                 )
                 self.mouse_tile_pos = tile_pos
+                # and add the rest of the shape if needed
+                if self.draw_shape_with_cursor:
+                    shape_tiles = [
+                        (tile_pos[0] + offset[0], tile_pos[1] + offset[1])
+                        for offset in self.cursor_shape_offsets
+                    ]
+                    self.draw_grid_shape(shape_tiles, color=self.grid_color)
             else:
                 self.mouse_tile_pos = None
 

--- a/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
@@ -18,6 +18,7 @@ class UserInputManager:
         self.cursor_shape_offsets = []
         self.default_grid_color = 3
         self.grid_color = self.default_grid_color
+        self.valid_starting_squares = []
 
     def update(self):
         if pyxel.btnp(pyxel.KEY_ESCAPE):
@@ -49,7 +50,10 @@ class UserInputManager:
                 )
                 self.mouse_tile_pos = tile_pos
                 # and add the rest of the shape if needed
-                if self.draw_shape_with_cursor:
+                if (
+                    self.draw_shape_with_cursor
+                    and tile_pos in self.valid_starting_squares
+                ):
                     shape_tiles = [
                         (tile_pos[0] + offset[0], tile_pos[1] + offset[1])
                         for offset in self.cursor_shape_offsets

--- a/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
@@ -112,3 +112,14 @@ class UserInputManager:
         self.input = ""
         self.accept_mouse_input = True
         self.prompt = prompt
+
+    def draw_grid_shape(self, tiles, color):
+        for tile in tiles:
+            if tile not in self.view_manager.map_view.valid_map_coordinates:
+                continue
+            x, y = self.view_manager.map_view.convert_grid_to_pixel_pos(
+                tile[0], tile[1]
+            )
+            self.view_manager.draw_grid(
+                x, y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, color
+            )

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -433,18 +433,16 @@ class HighlightMapTiles(Task):
     tiles: list[tuple[int, int]]
 
     def perform(self, view_manager, user_input_manager):
-        from pyxel_ui.constants import MAP_TILE_HEIGHT_PX, MAP_TILE_WIDTH_PX
-
-        for tile in self.tiles:
-            if tile not in view_manager.map_view.valid_map_coordinates:
-                continue
-            x, y = view_manager.map_view.convert_grid_to_pixel_pos(tile[0], tile[1])
-            view_manager.draw_grid(
-                x, y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, self.color
-            )
+        user_input_manager.draw_grid_shape(self.tiles, self.color)
 
 
 @dataclass
 class RedrawMap(Task):
     def perform(self, view_manager, user_input_manager):
         view_manager.map_view.draw()
+
+
+@dataclass
+class AdjustCursorGridShape(Task):
+    def perform(self, view_manager, user_input_manager):
+        pass

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -446,11 +446,13 @@ class RedrawMap(Task):
 class DrawCursorGridShape(Task):
     tile_shape_offsets: list[tuple[int, int]]
     grid_color: int
+    valid_starting_squares: list[tuple[int, int]]
 
     def perform(self, view_manager, user_input_manager):
         user_input_manager.draw_shape_with_cursor = True
         user_input_manager.cursor_shape_offsets = self.tile_shape_offsets
         user_input_manager.grid_color = self.grid_color
+        user_input_manager.valid_starting_squares = self.valid_starting_squares
 
 
 @dataclass
@@ -459,3 +461,4 @@ class TurnOffCursorGridShape(Task):
         user_input_manager.draw_shape_with_cursor = False
         user_input_manager.cursor_shape_offsets = []
         user_input_manager.grid_color = user_input_manager.default_grid_color
+        user_input_manager.valid_starting_squares = []

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -443,6 +443,19 @@ class RedrawMap(Task):
 
 
 @dataclass
-class AdjustCursorGridShape(Task):
+class DrawCursorGridShape(Task):
+    tile_shape_offsets: list[tuple[int, int]]
+    grid_color: int
+
     def perform(self, view_manager, user_input_manager):
-        pass
+        user_input_manager.draw_shape_with_cursor = True
+        user_input_manager.cursor_shape_offsets = self.tile_shape_offsets
+        user_input_manager.grid_color = self.grid_color
+
+
+@dataclass
+class TurnOffCursorGridShape(Task):
+    def perform(self, view_manager, user_input_manager):
+        user_input_manager.draw_shape_with_cursor = False
+        user_input_manager.cursor_shape_offsets = []
+        user_input_manager.grid_color = user_input_manager.default_grid_color

--- a/Gloomhaven/pyxel_ui/models/view_section.py
+++ b/Gloomhaven/pyxel_ui/models/view_section.py
@@ -117,11 +117,11 @@ class LogView(ViewSection):
 
         self.text_pixels = []
 
-        def get_line_height(text: str) -> int:
+        def get_line_height(text: str, size: str = "medium") -> int:
             return (
                 self.font.get_text_height(
                     text,
-                    size="medium",
+                    size=size,
                     max_width=self.bounding_coordinate[0] - self.start_pos[0],
                 )
                 + 4
@@ -138,7 +138,7 @@ class LogView(ViewSection):
                     max_width=self.bounding_coordinate[0] - self.start_pos[0],
                 )
             )
-            return y_pos + get_line_height(text)
+            return y_pos + get_line_height(text, size)
 
         current_y = self.start_pos[1]
         available_height = self.bounding_coordinate[1] - self.start_pos[1]
@@ -146,7 +146,7 @@ class LogView(ViewSection):
         # Try to draw header
         if self.display_round_turn:
             header = f"Round {self.round_number}, {self.acting_character_name}'s turn"
-            header_height = get_line_height(header)
+            header_height = get_line_height(header, "large")
 
             if header_height <= available_height:
                 current_y = draw_line(header, current_y, "large")

--- a/Gloomhaven/requirements.txt
+++ b/Gloomhaven/requirements.txt
@@ -1,7 +1,3 @@
-attrs==24.2.0
-charset-normalizer==3.4.0
-click==8.1.7
-decorator==5.1.1
 flask==3.1.0
 pillow==11.0.0
 pyxel==2.2.7


### PR DESCRIPTION
- made it so you can throw area attacks (elements and/or damage) at any square on the board rather than at a character only
- shape moves with the cursor
- prevented turn header from overflowing log area
- fixed some bugs
- collapsed area attack and element attack from self