### PR TITLE
Playtest improvements 2

### DIFF
--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -510,6 +510,7 @@ class PushAllEnemies(ActionStep):
                 board,
                 is_legal_push_check,
                 attacker.client_id,
+                is_push=True,
             )
 
     def __str__(self):

--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -95,7 +95,6 @@ class AreaAttackWithTarget(ActionStep):
             self.shape.add((0, 0))
         else:
             self.shape.discard((0, 0))
-        print(f"shape in action_model.area_attack_with_target: {self.shape}")
         rotated_offset_shape = attacker.pick_rotated_attack_coordinates(
             board, self.shape, attacker_loc, from_self=False
         )

--- a/Gloomhaven/backend/models/action_model.py
+++ b/Gloomhaven/backend/models/action_model.py
@@ -32,7 +32,6 @@ class AreaAttackFromSelf(ActionStep):
     def perform(self, board, attacker, round_num):
         # first create the attack coordinates from the shape (offsets)
         starting_coord = board.find_location_of_target(attacker)
-        self.shape.discard((0, 0))  # don't attack yourself
         attack_coords = attacker.pick_rotated_attack_coordinates(
             board, self.shape, starting_coord
         )

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -370,7 +370,13 @@ class Human(Agent):
         client_id: Optional[str] = None,
         is_push=False,
     ):
-        push_pull_str = "push" if is_push else "pull"
+        if is_push:
+            push_pull_str = "push"
+        elif movement_check:
+            push_pull_str = "pull"
+        # if there's no movement check, it's moving an ally
+        else:
+            push_pull_str = "move"
         Human.perform_movement(
             char_to_move,
             movement,

--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -352,7 +352,7 @@ class Human(Agent):
                 prompt = orig_prompt
                 continue
             else:
-                prompt = "Invalid square (obstacle, character, or out of movement range) - try again\nClick where you want to move."
+                prompt = "Invalid square (obstacle, character, or out of movement range) - try again"
 
         # board doesn't deal damage to jumping Humans, because they move step by step, so deal final damage here
         if is_jump:

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -431,7 +431,15 @@ class Board:
             for new_pos, new_g_score in valid_neighbors:
                 g_scores[new_pos] = new_g_score
                 h_score = calculate_chebyshev_distance(new_pos, end)
-                heapq.heappush(priority_queue, (new_g_score + h_score, new_pos))
+                # punish moves that go diagonally but don't have to by adding a small penalty
+                is_diagonal = (
+                    abs(new_pos[0] - current[0]) + abs(new_pos[1] - current[1]) == 2
+                )  # True for diagonal moves
+                tiebreaker = 0.001 if is_diagonal else 0
+                heapq.heappush(
+                    priority_queue, (new_g_score + h_score + tiebreaker, new_pos)
+                )
+                # heapq.heappush(priority_queue, (new_g_score + h_score, new_pos))
                 previous_cell[new_pos] = current
 
             closed.add(current)

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -733,11 +733,10 @@ class Board:
                 if self.round_num - el.round_placed > el.duration:
                     self.clear_terrain_square(i, j)
 
-    def update_character_statuses(self):
-        for char in self.characters:
-            if char.shield[1] <= self.round_num:
-                # reset to shield 0 indefinitely
-                character.shield = (0, MAX_ROUNDS)
+    def update_character_statuses(self, char: Character):
+        if char.shield[1] <= self.round_num:
+            # reset to shield 0 indefinitely
+            character.shield = (0, MAX_ROUNDS)
 
     def append_to_attack_modifier_deck(self, target: Character, modifier_card: tuple):
         target.attack_modifier_deck.append(modifier_card)

--- a/Gloomhaven/backend/models/campaign_manager.py
+++ b/Gloomhaven/backend/models/campaign_manager.py
@@ -104,23 +104,28 @@ class Campaign:
         return game.start()
 
     def run_levels(self):
-        for i, _ in enumerate(self.levels):
+        for _ in self.levels:
             output, message = self.run_level(self.levels.pop(0))
-
-            # if you don't win the level or if all levels are done, end here
-            if output != GameState.WIN or not self.levels:
+            # if you don't win the level, end here
+            if output != GameState.WIN:
                 self.pyxel_manager.pause_for_all_players(
                     num_players=self.num_players,
-                    prompt=message + "\nPress esc to enter",
+                    prompt=message + "\nPress esc to exit",
                 )
-                # !!! should clean up gracefully here
                 return
-            # otherwise, let them see end game message then
-            # offer to save and continue to next level
+            # otherwise, let them see the victory message and choose to progress
             self.pyxel_manager.pause_for_all_players(
                 num_players=self.num_players,
                 prompt=message + "\nAll players must press enter to continue",
             )
+            # if we're done, show the game ending plot and exit when everyone proceeds
+            if not self.levels:
+                game_end_text = """The Orchestrator raises a trembling hand, their eyes wide with disbelief. 'But I was supposed to-' they begin, but their words dissolve into mist along with their form, scattering like smoke on the wind. The unnatural darkness plaguing Drudgeford lifts like a veil, and warm sunlight touches the village for the first time in what feels like ages. As color returns to the withered crops and the mysterious runes fade from the doors, you hear the sounds of your neighbors emerging from their homes - their eyes clear, their movements their own again. You've seen horrors that will haunt your dreams for years to come, but looking at the restored peace in your village, you know it was worth the cost. Still, as night falls and shadows stretch across your floor, you can't help but wonder if somewhere, in some dark corner of reality, another Orchestrator is beginning their work."""
+                self.pyxel_manager.load_plot_screen(
+                    game_end_text, True, self.num_players
+                )
+                return
+            # if they're not done yet, offer to save campaign
             # self.save_campaign()
 
     def set_num_players(self):

--- a/Gloomhaven/backend/models/campaign_manager.py
+++ b/Gloomhaven/backend/models/campaign_manager.py
@@ -118,6 +118,10 @@ class Campaign:
                 num_players=self.num_players,
                 prompt=message + "\nAll players must press enter to continue",
             )
+            # reset the view manager
+            print("resetting view manager")
+            self.pyxel_manager.reset_view_manager()
+            print("done")
             # if we're done, show the game ending plot and exit when everyone proceeds
             if not self.levels:
                 game_end_text = """The Orchestrator raises a trembling hand, their eyes wide with disbelief. 'But I was supposed to-' they begin, but their words dissolve into mist along with their form, scattering like smoke on the wind. The unnatural darkness plaguing Drudgeford lifts like a veil, and warm sunlight touches the village for the first time in what feels like ages. As color returns to the withered crops and the mysterious runes fade from the doors, you hear the sounds of your neighbors emerging from their homes - their eyes clear, their movements their own again. You've seen horrors that will haunt your dreams for years to come, but looking at the restored peace in your village, you know it was worth the cost. Still, as night falls and shadows stretch across your floor, you can't help but wonder if somewhere, in some dark corner of reality, another Orchestrator is beginning their work."""

--- a/Gloomhaven/backend/models/character.py
+++ b/Gloomhaven/backend/models/character.py
@@ -694,6 +694,7 @@ class BloodOoze(Character):
             name, pyxel_manager, emoji, agent, char_id, is_monster, log, player_id
         )
         self.pyxel_sprite_name = "bloodooze"
+        self.elemental_affinity = obstacle.RottingFlesh
 
     def create_action_cards(self):
         return character_classes.bloodooze.cards

--- a/Gloomhaven/backend/models/character_classes/bloodooze.py
+++ b/Gloomhaven/backend/models/character_classes/bloodooze.py
@@ -54,4 +54,4 @@ cards = [
     ),
 ]
 
-health = 4
+health = 3

--- a/Gloomhaven/backend/models/character_classes/puppet.py
+++ b/Gloomhaven/backend/models/character_classes/puppet.py
@@ -6,8 +6,8 @@ cards = [
     actions.ActionCard(
         attack_name="Critical Meltdown",
         actions=[
-            actions.ModifySelfHealth(-5),
             actions.AreaAttackFromSelf(shape=shapes.circle(2), strength=6),
+            actions.ModifySelfHealth(-5),
         ],
         movement=3,
         jump=False,
@@ -54,4 +54,4 @@ cards = [
     ),
 ]
 
-health = 4
+health = 3

--- a/Gloomhaven/backend/models/character_classes/tank_melee.py
+++ b/Gloomhaven/backend/models/character_classes/tank_melee.py
@@ -2,55 +2,55 @@ from backend.models import action_model as actions
 from backend.utils import attack_shapes as shapes
 
 cards = [
-    actions.ActionCard(
-        attack_name="Crushing Advance",
-        actions=[actions.SingleTargetAttack(3, 1)],
-        movement=2,
-        jump=False,
-    ),
+    # actions.ActionCard(
+    #     attack_name="Crushing Advance",
+    #     actions=[actions.SingleTargetAttack(3, 1)],
+    #     movement=2,
+    #     jump=False,
+    # ),
     actions.ActionCard(
         attack_name="Defensive Stance",
         actions=[actions.ShieldSelf(3, 1), actions.SingleTargetAttack(4, 1)],
         movement=2,
         jump=False,
     ),
-    actions.ActionCard(
-        attack_name="Sweeping Blow",
-        actions=[actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=2)],
-        movement=3,
-        jump=False,
-    ),
-    actions.ActionCard(
-        attack_name="Shield Wall",
-        actions=[
-            actions.ShieldAllAllies(2, 1, 3),
-            actions.ModifySelfHealth(2),
-            actions.ChargeNextAttack(2),
-        ],
-        movement=0,
-        jump=False,
-    ),
-    actions.ActionCard(
-        attack_name="Grappling Strike",
-        actions=[
-            actions.Pull(2, 3),
-            actions.SingleTargetAttack(3, 1),
-        ],
-        movement=1,
-        jump=False,
-    ),
-    actions.ActionCard(
-        attack_name="Shield Bash",
-        actions=[actions.SingleTargetAttack(4, 1), actions.Push(2, 1)],
-        movement=2,
-        jump=False,
-    ),
-    actions.ActionCard(
-        attack_name="Recuperating Blow",
-        actions=[actions.SingleTargetAttack(4, 1), actions.ModifySelfHealth(2)],
-        movement=2,
-        jump=False,
-    ),
+    # actions.ActionCard(
+    #     attack_name="Sweeping Blow",
+    #     actions=[actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=2)],
+    #     movement=3,
+    #     jump=False,
+    # ),
+    # actions.ActionCard(
+    #     attack_name="Shield Wall",
+    #     actions=[
+    #         actions.ShieldAllAllies(2, 1, 3),
+    #         actions.ModifySelfHealth(2),
+    #         actions.ChargeNextAttack(2),
+    #     ],
+    #     movement=0,
+    #     jump=False,
+    # ),
+    # actions.ActionCard(
+    #     attack_name="Grappling Strike",
+    #     actions=[
+    #         actions.Pull(2, 3),
+    #         actions.SingleTargetAttack(3, 1),
+    #     ],
+    #     movement=1,
+    #     jump=False,
+    # ),
+    # actions.ActionCard(
+    #     attack_name="Shield Bash",
+    #     actions=[actions.SingleTargetAttack(4, 1), actions.Push(2, 1)],
+    #     movement=2,
+    #     jump=False,
+    # ),
+    # actions.ActionCard(
+    #     attack_name="Recuperating Blow",
+    #     actions=[actions.SingleTargetAttack(4, 1), actions.ModifySelfHealth(2)],
+    #     movement=2,
+    #     jump=False,
+    # ),
 ]
 
 health = 7

--- a/Gloomhaven/backend/models/character_classes/tank_melee.py
+++ b/Gloomhaven/backend/models/character_classes/tank_melee.py
@@ -2,55 +2,55 @@ from backend.models import action_model as actions
 from backend.utils import attack_shapes as shapes
 
 cards = [
-    # actions.ActionCard(
-    #     attack_name="Crushing Advance",
-    #     actions=[actions.SingleTargetAttack(3, 1)],
-    #     movement=2,
-    #     jump=False,
-    # ),
+    actions.ActionCard(
+        attack_name="Crushing Advance",
+        actions=[actions.SingleTargetAttack(3, 1)],
+        movement=2,
+        jump=False,
+    ),
     actions.ActionCard(
         attack_name="Defensive Stance",
         actions=[actions.ShieldSelf(3, 1), actions.SingleTargetAttack(4, 1)],
         movement=2,
         jump=False,
     ),
-    # actions.ActionCard(
-    #     attack_name="Sweeping Blow",
-    #     actions=[actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=2)],
-    #     movement=3,
-    #     jump=False,
-    # ),
-    # actions.ActionCard(
-    #     attack_name="Shield Wall",
-    #     actions=[
-    #         actions.ShieldAllAllies(2, 1, 3),
-    #         actions.ModifySelfHealth(2),
-    #         actions.ChargeNextAttack(2),
-    #     ],
-    #     movement=0,
-    #     jump=False,
-    # ),
-    # actions.ActionCard(
-    #     attack_name="Grappling Strike",
-    #     actions=[
-    #         actions.Pull(2, 3),
-    #         actions.SingleTargetAttack(3, 1),
-    #     ],
-    #     movement=1,
-    #     jump=False,
-    # ),
-    # actions.ActionCard(
-    #     attack_name="Shield Bash",
-    #     actions=[actions.SingleTargetAttack(4, 1), actions.Push(2, 1)],
-    #     movement=2,
-    #     jump=False,
-    # ),
-    # actions.ActionCard(
-    #     attack_name="Recuperating Blow",
-    #     actions=[actions.SingleTargetAttack(4, 1), actions.ModifySelfHealth(2)],
-    #     movement=2,
-    #     jump=False,
-    # ),
+    actions.ActionCard(
+        attack_name="Sweeping Blow",
+        actions=[actions.AreaAttackFromSelf(shape=shapes.cone(2), strength=2)],
+        movement=3,
+        jump=False,
+    ),
+    actions.ActionCard(
+        attack_name="Shield Wall",
+        actions=[
+            actions.ShieldAllAllies(2, 1, 3),
+            actions.ModifySelfHealth(2),
+            actions.ChargeNextAttack(2),
+        ],
+        movement=0,
+        jump=False,
+    ),
+    actions.ActionCard(
+        attack_name="Grappling Strike",
+        actions=[
+            actions.Pull(2, 3),
+            actions.SingleTargetAttack(3, 1),
+        ],
+        movement=1,
+        jump=False,
+    ),
+    actions.ActionCard(
+        attack_name="Shield Bash",
+        actions=[actions.SingleTargetAttack(4, 1), actions.Push(2, 1)],
+        movement=2,
+        jump=False,
+    ),
+    actions.ActionCard(
+        attack_name="Recuperating Blow",
+        actions=[actions.SingleTargetAttack(4, 1), actions.ModifySelfHealth(2)],
+        movement=2,
+        jump=False,
+    ),
 ]
 
 health = 7

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -265,16 +265,12 @@ class GameLoop:
             self.pyxel_manager.log.clear()
 
     def _end_round(self) -> None:
-        for char in self.board.characters:
-            self.refresh_character_cards(char)
         if not self.all_ai_mode:
             # 0 because that's the default round number
             self.pyxel_manager.load_round_turn_info(0, None)
-            # for i in range(1, self.num_players):
-            #     self.pyxel_manager.print_message(
-            #         "End of round. Waiting for Player 1 to hit continue",
-            #         f"frontend_{i+1}",
-            #     )
+        for char in self.board.characters:
+            self.refresh_character_cards(char)
+        if not self.all_ai_mode:
             self.pyxel_manager.pause_for_all_players(
                 num_players=self.num_players,
                 prompt="End of round. All players must hit enter to continue",

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -176,6 +176,8 @@ class GameLoop:
                 )
                 self._end_turn()
                 return
+            # before they pick a card, show them the shields of all their enemies:
+            self.display_enemy_shield_info(acting_character)
             action_card = acting_character.select_action_card()
             self.pyxel_manager.log.append(
                 f"{acting_character.name} chose {action_card.attack_name}\n"
@@ -230,6 +232,18 @@ class GameLoop:
             pass
 
         self._end_turn()
+
+    def display_enemy_shield_info(self, acting_character: character.Character) -> None:
+        """
+        prints shield info to the log if any enemies have shields
+        """
+        shield_info = [
+            f"{char.name}: {char.shield[0]}"
+            for char in self.board.characters
+            if char.team_monster != acting_character.team_monster and char.shield[0] > 0
+        ]
+        if shield_info:
+            self.pyxel_manager.log.append(f"Enemy Shields: {', '.join(shield_info)}")
 
     def check_and_update_game_state(self) -> None:
         # if all the monsters are dead, player wins

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -161,13 +161,6 @@ class GameLoop:
 
     def run_turn(self, acting_character: character.Character, round_num: int) -> None:
         self.board.acting_character = acting_character
-        if acting_character.lose_turn:
-            acting_character.lose_turn = False
-            self.pyxel_manager.log.append(
-                f"{acting_character.name} was knocked down and lost their turn."
-            )
-            self._end_turn()
-            return
         try:
             if acting_character.shield[0] > 0:
                 self.pyxel_manager.log.append(
@@ -175,6 +168,14 @@ class GameLoop:
                 )
             # take damage from elements before starting turn
             self.board.deal_terrain_damage_current_location(acting_character)
+            # if they lost their turn, skip it
+            if acting_character.lose_turn:
+                acting_character.lose_turn = False
+                self.pyxel_manager.log.append(
+                    f"{acting_character.name} was knocked down and lost their turn."
+                )
+                self._end_turn()
+                return
             action_card = acting_character.select_action_card()
             self.pyxel_manager.log.append(
                 f"{acting_character.name} chose {action_card.attack_name}\n"

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -240,9 +240,9 @@ class GameLoop:
             self.game_state = GameState.GAME_OVER
 
     def _end_game(self) -> GameState:
-        print("resetting view manager")
-        self.pyxel_manager.reset_view_manager()
-        print("done")
+        # print("resetting view manager")
+        # self.pyxel_manager.reset_view_manager()
+        # print("done")
         message = ""
         if self.game_state == GameState.GAME_OVER:
             message = self._lose_game_dead()

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -81,7 +81,6 @@ class GameLoop:
         round_character_list = list(self.board.characters)
         self.pyxel_manager.load_characters(self.board.characters)
         for acting_character in round_character_list:
-            print([char.name for char in round_character_list])
             # since we use a copy, we need to make sure the character is still alive
             if acting_character not in self.board.characters:
                 return

--- a/Gloomhaven/backend/models/game_loop.py
+++ b/Gloomhaven/backend/models/game_loop.py
@@ -72,8 +72,6 @@ class GameLoop:
     def run_round(self, round_num: int, is_test: bool = False) -> None:
         # clear the elements from the board that have "expired"
         self.board.update_terrain()
-        self.board.update_character_statuses()
-
         # if we don't shuffle the actual list, we will create ordering issues
         # b/c when we kill a character, we send a copy of characters over to
         # pyxel, same when we update healths
@@ -162,6 +160,8 @@ class GameLoop:
     def run_turn(self, acting_character: character.Character, round_num: int) -> None:
         self.board.acting_character = acting_character
         try:
+            # reset any statuses that should expire on their turn
+            self.board.update_character_statuses(acting_character)
             if acting_character.shield[0] > 0:
                 self.pyxel_manager.log.append(
                     (f"{acting_character.name} has shield {acting_character.shield[0]}")

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -20,7 +20,7 @@ campaign_levels = [
     Level(
         floor_color_map=[(1, 3), (5, 11)],
         wall_color_map=[(1, 4), (13, 15)],
-        monster_classes=[character.Fairy],
+        monster_classes=[character.Treeman],
         # monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
         pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
         starting_elements=[obstacle.Spores, obstacle.PoisonShroom],

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -83,5 +83,3 @@ campaign_levels = [
         ],
     ),
 ]
-
-# The Orchestrator raises a trembling hand, their eyes wide with disbelief. "But I was supposed to-" they begin, but their words dissolve into mist along with their form, scattering like smoke on the wind. The unnatural darkness plaguing Drudgeford lifts like a veil, and warm sunlight touches the village for the first time in what feels like ages. As color returns to the withered crops and the mysterious runes fade from the doors, you hear the sounds of your neighbors emerging from their homes - their eyes clear, their movements their own again. You've seen horrors that will haunt your dreams for years to come, but looking at the restored peace in your village, you know it was worth the cost. Still, as night falls and shadows stretch across your floor, you can't help but wonder if somewhere, in some dark corner of reality, another Orchestrator is beginning their work.

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -17,64 +17,62 @@ class Level:
 
 
 campaign_levels = [
+    # Level(
+    #     floor_color_map=[(1, 3), (5, 11)],
+    #     wall_color_map=[(1, 4), (13, 15)],
+    #     monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+    #     pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
+    #     starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
+    # ),
+    # Level(
+    #     floor_color_map=[(1, 8), (5, 2)],
+    #     wall_color_map=[],  # (1,2), (13,14)
+    #     monster_classes=[character.Demon, character.Fiend, character.FireSprite],
+    #     pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
+    #     starting_elements=[
+    #         obstacle.Fire,
+    #         obstacle.Fire,
+    #         obstacle.Trap,
+    #         obstacle.Shadow,
+    #     ],
+    # ),
+    # Level(
+    #     floor_color_map=[(1, 6), (5, 7)],
+    #     wall_color_map=[(13, 12)],
+    #     monster_classes=[
+    #         character.SnowStalker,
+    #         character.IceMonster,
+    #         character.IceDragon,
+    #     ],
+    #     pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
+    #     starting_elements=[obstacle.Ice, obstacle.Trap],
+    # ),
+    # Level(
+    #     floor_color_map=[],
+    #     wall_color_map=[],
+    #     monster_classes=[
+    #         character.Ghost,
+    #         character.WailingSpirit,
+    #         character.Corpse,
+    #         character.Skeleton,
+    #     ],
+    #     pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
+    #     starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
+    # ),
+    # Level(
+    #     floor_color_map=[(1, 8), (5, 14)],
+    #     wall_color_map=[(1, 2), (13, 8)],
+    #     monster_classes=[
+    #         character.MalformedFlesh,
+    #         character.FleshGolem,
+    #         character.BloodOoze,
+    #     ],
+    #     pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
+    #     starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
+    # ),
     Level(
-        floor_color_map=[(1, 3), (5, 11)],
-        wall_color_map=[(1, 4), (13, 15)],
-        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
-        pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
-        starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
-    ),
-    Level(
-        floor_color_map=[(1, 8), (5, 2)],
-        wall_color_map=[],  # (1,2), (13,14)
-        monster_classes=[character.Demon, character.Fiend, character.FireSprite],
-        pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
-        starting_elements=[
-            obstacle.Fire,
-            obstacle.Fire,
-            obstacle.Trap,
-            obstacle.Shadow,
-        ],
-    ),
-    Level(
-        floor_color_map=[(1, 6), (5, 7)],
-        wall_color_map=[(13, 12)],
-        monster_classes=[
-            character.SnowStalker,
-            character.IceMonster,
-            character.IceDragon,
-        ],
-        pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
-        starting_elements=[obstacle.Ice, obstacle.Trap],
-    ),
-    Level(
-        floor_color_map=[],
-        wall_color_map=[],
-        monster_classes=[
-            character.Ghost,
-            character.WailingSpirit,
-            character.Corpse,
-            character.Skeleton,
-        ],
-        pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
-        starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
-    ),
-    Level(
-        floor_color_map=[(1, 8), (5, 14)],
-        wall_color_map=[(1, 2), (13, 8)],
-        monster_classes=[
-            character.MalformedFlesh,
-            character.FleshGolem,
-            character.BloodOoze,
-        ],
-        pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
-        starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
-    ),
-    Level(
-        floor_color_map=[
-            (5, 13),
-        ],
-        wall_color_map=[],
+        floor_color_map=[(5, 9), (1, 4)],
+        wall_color_map=[(13, 4), (1, 0)],
         monster_classes=[character.Puppet, character.Puppet, character.Orchestrator],
         pre_level_text="""As the flesh-chamber convulses one final time, reality tears itself apart and then snaps back into focus. You find yourself standing in Drudgeford once again - but not as you remember it. The village square stretches before you, warped by unnatural shadows, and at its center stands the one you've been pursuing: the Orchestrator. Their hood falls back revealing a face that's both ancient and impossibly young, twisted by the dark forces they command. "You've survived every nightmare I could conjure," they snarl, dark energy crackling between their fingers. "But here, where it all began, I'll show you my true power." The fate of your home hangs in the balance as you ready yourself for the final battle, knowing that either your village will see another dawn - or be lost forever to the Orchestrator's darkness.""",
         starting_elements=[

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -17,59 +17,59 @@ class Level:
 
 
 campaign_levels = [
-    # Level(
-    #     floor_color_map=[(1, 3), (5, 11)],
-    #     wall_color_map=[(1, 4), (13, 15)],
-    #     monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
-    #     pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
-    #     starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 8), (5, 2)],
-    #     wall_color_map=[],  # (1,2), (13,14)
-    #     monster_classes=[character.Demon, character.Fiend, character.FireSprite],
-    #     pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
-    #     starting_elements=[
-    #         obstacle.Fire,
-    #         obstacle.Fire,
-    #         obstacle.Trap,
-    #         obstacle.Shadow,
-    #     ],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 6), (5, 7)],
-    #     wall_color_map=[(13, 12)],
-    #     monster_classes=[
-    #         character.SnowStalker,
-    #         character.IceMonster,
-    #         character.IceDragon,
-    #     ],
-    #     pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
-    #     starting_elements=[obstacle.Ice, obstacle.Trap],
-    # ),
-    # Level(
-    #     floor_color_map=[],
-    #     wall_color_map=[],
-    #     monster_classes=[
-    #         character.Ghost,
-    #         character.WailingSpirit,
-    #         character.Corpse,
-    #         character.Skeleton,
-    #     ],
-    #     pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
-    #     starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 8), (5, 14)],
-    #     wall_color_map=[(1, 2), (13, 8)],
-    #     monster_classes=[
-    #         character.MalformedFlesh,
-    #         character.FleshGolem,
-    #         character.BloodOoze,
-    #     ],
-    #     pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
-    #     starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
-    # ),
+    Level(
+        floor_color_map=[(1, 3), (5, 11)],
+        wall_color_map=[(1, 4), (13, 15)],
+        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+        pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
+        starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
+    ),
+    Level(
+        floor_color_map=[(1, 8), (5, 2)],
+        wall_color_map=[],  # (1,2), (13,14)
+        monster_classes=[character.Demon, character.Fiend, character.FireSprite],
+        pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
+        starting_elements=[
+            obstacle.Fire,
+            obstacle.Fire,
+            obstacle.Trap,
+            obstacle.Shadow,
+        ],
+    ),
+    Level(
+        floor_color_map=[(1, 6), (5, 7)],
+        wall_color_map=[(13, 12)],
+        monster_classes=[
+            character.SnowStalker,
+            character.IceMonster,
+            character.IceDragon,
+        ],
+        pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
+        starting_elements=[obstacle.Ice, obstacle.Trap],
+    ),
+    Level(
+        floor_color_map=[],
+        wall_color_map=[],
+        monster_classes=[
+            character.Ghost,
+            character.WailingSpirit,
+            character.Corpse,
+            character.Skeleton,
+        ],
+        pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
+        starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
+    ),
+    Level(
+        floor_color_map=[(1, 8), (5, 14)],
+        wall_color_map=[(1, 2), (13, 8)],
+        monster_classes=[
+            character.MalformedFlesh,
+            character.FleshGolem,
+            character.BloodOoze,
+        ],
+        pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
+        starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
+    ),
     Level(
         floor_color_map=[(5, 9), (1, 4)],
         wall_color_map=[(13, 4), (1, 0)],

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -17,25 +17,25 @@ class Level:
 
 
 campaign_levels = [
-    Level(
-        floor_color_map=[(1, 3), (5, 11)],
-        wall_color_map=[(1, 4), (13, 15)],
-        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
-        pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
-        starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
-    ),
-    Level(
-        floor_color_map=[(1, 8), (5, 2)],
-        wall_color_map=[],  # (1,2), (13,14)
-        monster_classes=[character.Demon, character.Fiend, character.FireSprite],
-        pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
-        starting_elements=[
-            obstacle.Fire,
-            obstacle.Fire,
-            obstacle.Trap,
-            obstacle.Shadow,
-        ],
-    ),
+    # Level(
+    #     floor_color_map=[(1, 3), (5, 11)],
+    #     wall_color_map=[(1, 4), (13, 15)],
+    #     monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+    #     pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
+    #     starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
+    # ),
+    # Level(
+    #     floor_color_map=[(1, 8), (5, 2)],
+    #     wall_color_map=[],  # (1,2), (13,14)
+    #     monster_classes=[character.Demon, character.Fiend, character.FireSprite],
+    #     pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
+    #     starting_elements=[
+    #         obstacle.Fire,
+    #         obstacle.Fire,
+    #         obstacle.Trap,
+    #         obstacle.Shadow,
+    #     ],
+    # ),
     Level(
         floor_color_map=[(1, 6), (5, 7)],
         wall_color_map=[(13, 12)],

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -20,7 +20,8 @@ campaign_levels = [
     Level(
         floor_color_map=[(1, 3), (5, 11)],
         wall_color_map=[(1, 4), (13, 15)],
-        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+        monster_classes=[character.Fairy],
+        # monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
         pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
         starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
     ),

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -20,8 +20,7 @@ campaign_levels = [
     Level(
         floor_color_map=[(1, 3), (5, 11)],
         wall_color_map=[(1, 4), (13, 15)],
-        monster_classes=[character.Treeman],
-        # monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
         pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
         starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
     ),

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -17,59 +17,59 @@ class Level:
 
 
 campaign_levels = [
-    # Level(
-    #     floor_color_map=[(1, 3), (5, 11)],
-    #     wall_color_map=[(1, 4), (13, 15)],
-    #     monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
-    #     pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
-    #     starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 8), (5, 2)],
-    #     wall_color_map=[],  # (1,2), (13,14)
-    #     monster_classes=[character.Demon, character.Fiend, character.FireSprite],
-    #     pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
-    #     starting_elements=[
-    #         obstacle.Fire,
-    #         obstacle.Fire,
-    #         obstacle.Trap,
-    #         obstacle.Shadow,
-    #     ],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 6), (5, 7)],
-    #     wall_color_map=[(13, 12)],
-    #     monster_classes=[
-    #         character.SnowStalker,
-    #         character.IceMonster,
-    #         character.IceDragon,
-    #     ],
-    #     pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
-    #     starting_elements=[obstacle.Ice, obstacle.Trap],
-    # ),
-    # Level(
-    #     floor_color_map=[],
-    #     wall_color_map=[],
-    #     monster_classes=[
-    #         character.Ghost,
-    #         character.WailingSpirit,
-    #         character.Corpse,
-    #         character.Skeleton,
-    #     ],
-    #     pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
-    #     starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
-    # ),
-    # Level(
-    #     floor_color_map=[(1, 8), (5, 14)],
-    #     wall_color_map=[(1, 2), (13, 8)],
-    #     monster_classes=[
-    #         character.MalformedFlesh,
-    #         character.FleshGolem,
-    #         character.BloodOoze,
-    #     ],
-    #     pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
-    #     starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
-    # ),
+    Level(
+        floor_color_map=[(1, 3), (5, 11)],
+        wall_color_map=[(1, 4), (13, 15)],
+        monster_classes=[character.Treeman, character.MushroomMan, character.Fairy],
+        pre_level_text="""A hunter you talked to at the tavern mentioned seeing the same mysterious rune that's been appearing on village doors carved into the bark of an ancient tree in a forest nearby. When the village healer mentioned that the mushrooms from that part of the forest had suddenly lost their curative effects, you decide to investigate the area. The rune on the tree points to a trail of withered vegetation. You follow it deep into the forest - only to find yourself surrounded by forest creatures whose vacant eyes and jerky movements suggest they're under some dark influence. Before you can retreat, they lunge at you in perfect, unsettling union.""",
+        starting_elements=[obstacle.Spores, obstacle.PoisonShroom],
+    ),
+    Level(
+        floor_color_map=[(1, 8), (5, 2)],
+        wall_color_map=[],  # (1,2), (13,14)
+        monster_classes=[character.Demon, character.Fiend, character.FireSprite],
+        pre_level_text="""As you kill the last of the corrupted creatures, a dark figure in a hooded robe materializes at the forest's edge. Before you can focus on it, the shape dissolves into shadow. Your head erupts into searing pain, as a raspy voice booms in your mind. 'I have you in my grasp now,' it cackles. 'Good luck ever escaping me.' The world spins, then fades to black as you collapse. You wake up burning hot, and your eyes open to the sight of demons and fire - you'll need to fight through them to survive.""",
+        starting_elements=[
+            obstacle.Fire,
+            obstacle.Fire,
+            obstacle.Trap,
+            obstacle.Shadow,
+        ],
+    ),
+    Level(
+        floor_color_map=[(1, 6), (5, 7)],
+        wall_color_map=[(13, 12)],
+        monster_classes=[
+            character.SnowStalker,
+            character.IceMonster,
+            character.IceDragon,
+        ],
+        pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
+        starting_elements=[obstacle.Ice, obstacle.Trap],
+    ),
+    Level(
+        floor_color_map=[],
+        wall_color_map=[],
+        monster_classes=[
+            character.Ghost,
+            character.WailingSpirit,
+            character.Corpse,
+            character.Skeleton,
+        ],
+        pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
+        starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
+    ),
+    Level(
+        floor_color_map=[(1, 8), (5, 14)],
+        wall_color_map=[(1, 2), (13, 8)],
+        monster_classes=[
+            character.MalformedFlesh,
+            character.FleshGolem,
+            character.BloodOoze,
+        ],
+        pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
+        starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
+    ),
     Level(
         floor_color_map=[
             (5, 13),

--- a/Gloomhaven/backend/models/level.py
+++ b/Gloomhaven/backend/models/level.py
@@ -36,40 +36,40 @@ campaign_levels = [
     #         obstacle.Shadow,
     #     ],
     # ),
-    Level(
-        floor_color_map=[(1, 6), (5, 7)],
-        wall_color_map=[(13, 12)],
-        monster_classes=[
-            character.SnowStalker,
-            character.IceMonster,
-            character.IceDragon,
-        ],
-        pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
-        starting_elements=[obstacle.Ice, obstacle.Trap],
-    ),
-    Level(
-        floor_color_map=[],
-        wall_color_map=[],
-        monster_classes=[
-            character.Ghost,
-            character.WailingSpirit,
-            character.Corpse,
-            character.Skeleton,
-        ],
-        pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
-        starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
-    ),
-    Level(
-        floor_color_map=[(1, 8), (5, 14)],
-        wall_color_map=[(1, 2), (13, 8)],
-        monster_classes=[
-            character.MalformedFlesh,
-            character.FleshGolem,
-            character.BloodOoze,
-        ],
-        pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
-        starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
-    ),
+    # Level(
+    #     floor_color_map=[(1, 6), (5, 7)],
+    #     wall_color_map=[(13, 12)],
+    #     monster_classes=[
+    #         character.SnowStalker,
+    #         character.IceMonster,
+    #         character.IceDragon,
+    #     ],
+    #     pre_level_text="""As the last demon falls, the infernal heat suddenly crystallizes into deadly cold. Your victory over the demons is cut short by a sinister laugh echoing through your mind and the realization that your journey is not taking you homeward. You crash onto a vast tundra, where howling winds whip endless sheets of snow and ice in every direction. Through the blinding white, you glimpse an ancient dragon's massive form circling overhead, its scales gleaming like shards of frozen starlight. You know instantly that this battle will be harder than all that came before.""",
+    #     starting_elements=[obstacle.Ice, obstacle.Trap],
+    # ),
+    # Level(
+    #     floor_color_map=[],
+    #     wall_color_map=[],
+    #     monster_classes=[
+    #         character.Ghost,
+    #         character.WailingSpirit,
+    #         character.Corpse,
+    #         character.Skeleton,
+    #     ],
+    #     pre_level_text="""Your last enemy crashes to the frozen earth with a thunderous impact that splinters the ice beneath. But as the snow settles, the ground continues to crack and decay, the pristine white turning to rotting soil. The crisp winter air grows thick with the stench of decay, and through the mist rising from freshly disturbed graves, you see hands prying their way out of the earth. Horrors beyond your darkest nightmares emerge from the shadows - translucent spirits wailing in eternal agony, ethereal wraiths drifting between tombstones, and things for which you have no name. The sheer number and intensity of these abominations makes one thing clear: whatever force has been testing you is now desperate to ensure you don't survive this nightmare.""",
+    #     starting_elements=[obstacle.Shadow, obstacle.Trap, obstacle.Shadow],
+    # ),
+    # Level(
+    #     floor_color_map=[(1, 8), (5, 14)],
+    #     wall_color_map=[(1, 2), (13, 8)],
+    #     monster_classes=[
+    #         character.MalformedFlesh,
+    #         character.FleshGolem,
+    #         character.BloodOoze,
+    #     ],
+    #     pre_level_text="""Your victory over the undead hordes is cut short as the mist-shrouded graveyard begins to pulse with an unnatural rhythm. Through the fog, you finally glimpse the hooded figure again - but this time they're stumbling backward, their confident posture replaced with panic. "No... impossible... you weren't supposed to make it this far!" they shriek before dissolving into shadow. The ground beneath you softens sickeningly, transforming from packed earth into something warm and organic. You find yourself in a grotesque chamber of living tissue, where half-formed creatures writhe in pools of viscous crimson, and monstrous flesh-golems lumber through pulsing tunnels of raw meat and sinew. The wet, rhythmic sounds of this place make your skin crawl as you realize you're trapped inside something impossibly vast and alive - but you're close now, so close to ending this nightmare.""",
+    #     starting_elements=[obstacle.RottingFlesh, obstacle.RottingFlesh],
+    # ),
     Level(
         floor_color_map=[
             (5, 13),


### PR DESCRIPTION
a bunch more small playtest improvements, including:
- bug fixes
- improving boss fight map color
- print improvements
- adding game end plot
- take element damage if you're knocked down
- reset shield at the start of your turn rather than start of round
- prioritize straight movements if they're the same path length as paths with diagonal movement
- don't clear map at end of level so you can see how the game ended
- display enemy shields when you take your turn