### PR TITLE
adding jump-only range visuals

### DIFF
--- a/Gloomhaven/backend/models/agent.py
+++ b/Gloomhaven/backend/models/agent.py
@@ -316,13 +316,20 @@ class Human(Agent):
             if char not in board.characters:
                 return
             current_loc = board.find_location_of_target(char)
+
+            if is_jump:
+                # reachable position is a radius of remaining_movement around current_loc
+                # reachable_paths is an empty dict
+                reachable_positions, reachable_paths = (
+                    board.find_all_jumpable_positions(current_loc, remaining_movement)
+                )
+            else:
+                # send reachable positions and the shortest valid paths to get to them.
+                reachable_positions, reachable_paths = board.find_all_reachable_paths(
+                    current_loc, remaining_movement
+                )
+
             # only allow user to pick a square in range
-
-            # send reachable positions and the shortest valid paths to get to them.
-            reachable_positions, reachable_paths = board.find_all_reachable_paths(
-                current_loc, remaining_movement, False, additional_movement_check
-            )
-
             new_row, new_col = char.pyxel_manager.get_user_input(
                 prompt=prompt + f"\nMovement remaining: {remaining_movement}",
                 is_mouse=True,

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -290,6 +290,7 @@ class Board:
             for d_x in bounds
             for d_y in bounds
             if self.is_legal_move(jump_x := start_x + d_x, jump_y := start_y + d_y)
+            and (jump_x, jump_y) != start
         ]
 
         # Flip and normalize, look to turn this into a function if we

--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -293,14 +293,6 @@ class Board:
             and (jump_x, jump_y) != start
         ]
 
-        # Flip and normalize, look to turn this into a function if we
-        # do this one more time.
-        jumpable_positions = [
-            pos
-            for x, y in jumpable_positions
-            for pos in [self.pyxel_manager.normalize_coordinate((y, x))]
-        ]
-
         return jumpable_positions, {}
 
     def find_all_reachable_paths(

--- a/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
+++ b/Gloomhaven/pyxel_ui/controllers/user_input_manager.py
@@ -17,6 +17,7 @@ class UserInputManager:
         self.input = ""
         self.last_mouse_pos = (-1, -1)
         self.mouse_tile_pos = None
+        self.mouse_px_pos = None
         self.prompt = ""
         self.server_client = server_client
         self.valid_starting_squares = []
@@ -47,6 +48,8 @@ class UserInputManager:
             grid_top_px = round_down_to_nearest_multiple(
                 curr_mouse_y, MAP_TILE_HEIGHT_PX, self.view_manager.view_border
             )
+            self.mouse_px_pos = (grid_left_px, grid_top_px)
+
             # draw the grid only if it's on mapview
             # store valid current map tile pos
             if tile_pos := self.view_manager.get_valid_map_coords_for_cursor_pos(
@@ -83,14 +86,14 @@ class UserInputManager:
                     pos_x, pos_y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, color=5
                 )
             if self.mouse_tile_pos and self.mouse_tile_pos in self.reachable_positions:
-                for path_x, path_y in self.reachable_paths_px[self.mouse_tile_pos]:
+                for path_x, path_y in self.reachable_paths_px.get(
+                    self.mouse_tile_pos, [self.mouse_px_pos]
+                ):
                     self.view_manager.draw_grid(
                         path_x, path_y, MAP_TILE_WIDTH_PX, MAP_TILE_HEIGHT_PX, color=7
                     )
             if pyxel.btnp(pyxel.MOUSE_BUTTON_LEFT) and self.mouse_tile_pos:
                 tile_pos_x, tile_pos_y = self.mouse_tile_pos
-                # BUG: location seems to be relative to character starting position so
-                # the target location will always be off by some amount, e.g. always 2 over.
                 self.view_manager.reset_personal_log()
                 self.accept_mouse_input = False
                 self.input = f"{tile_pos_y}, {tile_pos_x}"

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -241,7 +241,8 @@ class MouseInputTask(Task):
 
     def perform(self, view_manager, user_input_manager):
         user_input_manager.get_mouse_input(self.prompt)
-        if self.reachable_positions and self.reachable_paths:
+        # only checking for reachable_positions since paths can be empty for jumps
+        if self.reachable_positions:
             user_input_manager.set_reachable_values(
                 self.reachable_positions, self.reachable_paths
             )

--- a/Gloomhaven/pyxel_ui/models/tasks.py
+++ b/Gloomhaven/pyxel_ui/models/tasks.py
@@ -241,8 +241,8 @@ class MouseInputTask(Task):
 
     def perform(self, view_manager, user_input_manager):
         user_input_manager.get_mouse_input(self.prompt)
-        # only checking for reachable_positions since paths can be empty for jumps
-        if self.reachable_positions:
+        # reachable_paths is an empty dict for jumps
+        if self.reachable_positions and self.reachable_paths is not None:
             user_input_manager.set_reachable_values(
                 self.reachable_positions, self.reachable_paths
             )


### PR DESCRIPTION
players should be able to see how far they can jump and the range should not be affected by obstacles, e.g. you should be able to jump over walls to un-walkable areas or into isolated islands.

the algorithm for this is a bit brute force. it generates a block of with a radius of `num_moves` -- yeah, i'll say radius even though it's a square since diagonal movements cost the same as cardinal ones -- and checks every square to see if it's valid. I kinda don't think we can get more efficient here since we need to check every square to see if it's valid. Oh, i forgot to exclude the starting position.

i had to make some slight modifications to how we handle inputs on the FE since it expects both a list of accessible positions and a dict of paths to get there, but jumps don't care about paths one bit.

there's a bug where these areas and paths remain visible after movement, and that's due to the introduction of executing attacks via mouse clicks. we can resolve that by clearing the area and path data once the character is moved on the FE. we should be careful about the order in which we get movement tasks and mouse input tasks so that if a player wants to make smaller movements, we don't wipe new area and path data before they get a chance to act on it.