### PR TITLE
big air!

### DIFF
--- a/Gloomhaven/backend/models/board.py
+++ b/Gloomhaven/backend/models/board.py
@@ -649,7 +649,9 @@ class Board:
             path_traveled = path_traveled[-1:]
         for loc in path_traveled:
             # move character one step
-            self.update_character_location(acting_character, acting_character_loc, loc)
+            self.update_character_location(
+                acting_character, acting_character_loc, loc, is_jump
+            )
             acting_character_loc = loc
             # humans move step by step, so they should not take damage on a jump - we'll have them take damage
             # at the end of their movement later
@@ -705,11 +707,12 @@ class Board:
         actor: Character,
         old_location: tuple[int, int],
         new_location: tuple[int, int],
+        is_jump: bool = False,
     ) -> None:
         # Add action queue logic here.
         self.update_locations(old_location[0], old_location[1], None)
         self.update_locations(new_location[0], new_location[1], actor)
-        self.pyxel_manager.move_character(actor, old_location, new_location)
+        self.pyxel_manager.move_character(actor, old_location, new_location, is_jump)
 
     def is_legal_move(self, row: int, col: int, jump_intermediate_move=False) -> bool:
         is_position_within_board = (

--- a/Gloomhaven/backend/models/pyxel_backend.py
+++ b/Gloomhaven/backend/models/pyxel_backend.py
@@ -1,3 +1,8 @@
+"""
+This is what creates the tasks that are sent to the front-end which results
+in updates to the different view sections.
+"""
+
 import backend.models.character as character
 from itertools import cycle
 from pyxel_ui.models import tasks
@@ -84,12 +89,13 @@ class PyxelManager:
         self.log = ListWithUpdate([], self.load_log)
         self.load_log(self.log)
 
-    def move_character(self, char, old_location, new_location):
+    def move_character(self, char, old_location, new_location, is_jump=False):
         task = tasks.ActionTask(
             char.id,
             self.normalize_coordinate((old_location[1], old_location[0])),
             self.normalize_coordinate((new_location[1], new_location[0])),
             self.move_duration,
+            is_jump=is_jump,
         )
         self.jsonify_and_send_task(task)
 

--- a/Gloomhaven/pyxel_ui/models/entity.py
+++ b/Gloomhaven/pyxel_ui/models/entity.py
@@ -24,9 +24,9 @@ class Entity:
     # 0 upward, with higher priority number displaying on top
     priority: int
     alive: bool = True
+    scale: int = 1
 
-
-    def update_position(self, x: int, y: int):
+    def update_position(self, x: int, y: int) -> None:
         """
         Updates the entity's position on the canvas.
 
@@ -36,3 +36,6 @@ class Entity:
         """
         self.x = x
         self.y = y
+
+    def update_scale(self, scale: int) -> None:
+        self.scale = scale

--- a/Gloomhaven/pyxel_ui/models/view_section.py
+++ b/Gloomhaven/pyxel_ui/models/view_section.py
@@ -274,6 +274,7 @@ class MapView(ViewSection):
                         self.sprite_manager.get_sprite(
                             entity.name, entity.animation_frame
                         ),
+                        scale=entity.scale,
                     )
 
     def convert_grid_to_pixel_pos(self, tile_x: int, tile_y: int) -> tuple[int, int]:


### PR DESCRIPTION
it would be fun if jumps felt jumpy so this adds a way to specify scale in `ActionTask`. 

The scaling is handled by a parabolic function and we can experiment around with different formulas if it'll have a slighty better feel.

I also added a slight 1.2 scale to normal movements to give it more dimensional pop.

scaling in action. you gotta wait a bit for the big jump though.
![pyxel jumps](https://github.com/user-attachments/assets/f5cefbbc-e58f-4cc8-96b3-0b0d875b72ec)

we need to find a way to at least temporarily set jumping sprites to max priority because right now there's a chance of characters jumping under others.

we should also have push and pull use the jump workflow so we don't end up with people getting pull or pushed around obstacles.